### PR TITLE
[+] add AGENTS.md, vrf-workflow, and vrf-new-agent Claude Code skills

### DIFF
--- a/.claude/skills/vrf-new-agent/SKILL.md
+++ b/.claude/skills/vrf-new-agent/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: vrf-new-agent
+description: Scaffold a brand-new UVM verification agent (protocol block) under odve/comp/agents/ so it follows the framework's standard folder structure, file/class naming convention, and Makefile targets (make atb/adut/auvm/elab/all/run). Use this whenever the user asks to add, create, start, or bootstrap a new agent/block/VIP for a protocol (e.g. "add an ahb agent", "start the jtag agent", "create a new agent for spi") — do not hand-build the directory tree from scratch or copy an existing agent wholesale, since the existing agents (apb, axi) are inconsistent with each other and apb references a common-component base class that doesn't exist in this repo.
+---
+
+# Scaffolding a new odve agent
+
+Every agent in `odve/comp/agents/` is supposed to look the same, but today they don't: `apb` extends `ocdve_common_component`/`ocdve_common_driver`/`ocdve_common_monitor` from an `ocdve_common_pkg` that **doesn't exist anywhere in the repo** (grep for it — it's a dangling reference, apb doesn't currently compile), uses a flat `src/` with a top-level `item/`, and has several copy-paste bugs (`slave_driver.sv`'s tasks are defined under the wrong class name, a class named `oocdve_apb_seq_item` with a stray `o`, a `puvm_phase` typo). `axi` instead extends plain UVM base classes (`uvm_agent`/`uvm_driver`/`uvm_monitor`/`uvm_sequencer`) with no common-component layer, and nests `item/` and `mst/slv/mon/` under `src/agent/`.
+
+**`axi`'s pattern is the one to standardize on going forward** — it's self-consistent and doesn't depend on missing framework code. Do not copy `apb`'s structure or its `ocdve_`-prefixed naming for new agents.
+
+## Use the scaffold script, don't hand-build the tree
+
+```bash
+cd <path to open-dve repo root>          # the dir containing odve/comp/agents
+.claude/skills/vrf-new-agent/scripts/new_agent.sh <proto>
+```
+
+`<proto>` is the lowercase protocol name (`spi`, `jtag`, `uart2`, ...) and becomes the directory name under `odve/comp/agents/<proto>/`. The script is idempotent-safe (refuses to run if the target directory already exists) and generates the **complete, working skeleton**:
+
+- `intf/odve_<proto>_if.sv` — interface stub (clk/rst_n only; protocol signals are a TODO).
+- `src/item/odve_<proto>_item.sv` + `odve_<proto>_item_pkg.sv`.
+- `src/agent/odve_<proto>_cfg.sv`, `odve_<proto>_sqr.sv`, `odve_<proto>_agent.sv`, `odve_<proto>_agent_pkg.sv`, plus `mon/odve_<proto>_mon.sv`, `mst/odve_<proto>_mst_drv_base.sv`, `slv/odve_<proto>_slv_drv.sv` — all extending plain `uvm_*` base classes, wired together (agent creates/connects sqr+drv+mon, gets `cfg` via `uvm_config_db`) so it's a real, buildable starting point, not just empty files.
+- `list/agent.f`, `item.f`, `seq.f` — compile filelists already pointing at the generated files.
+- `vrf/dut/dut.sv`, `vrf/list/fl_{tb,dut,uvm}.f`, `vrf/tb/{top.sv,env/*,tests/*}` — a working standalone TB (env with `cc`/`scb` placeholders, `base_test`/`simple_test`) modeled on `axi`'s clean version (with `axi`'s one bug — `endclass : envi` instead of `endclass : env` — fixed).
+- `vrf/work/{common,run,mini,check}/{Makefile,sourceme,regress.py}` and `vrf/work/rlist/{mini,check,submit}.list` — the standard build/run/regress workspace, using the same `readlink -f "../../../../../../"` depth as `apb`'s (correct because the new agent sits at the same directory depth).
+
+This determinism matters: the trickiest thing to get right by hand is the `sourceme` relative-path depth (`ODVE=$(readlink -f "../../../../../../")`), which silently points at the wrong directory if any nesting level is off. The script gets it right every time because the generated tree is always the same depth.
+
+## After scaffolding
+
+1. Fill in the interface (`intf/odve_<proto>_if.sv`) with the protocol's real signals.
+2. Fill in the item (`src/item/odve_<proto>_item.sv`) with real transaction fields.
+3. Implement the driver/monitor logic marked `// TODO`.
+4. Any new `.sv` file must be added to the relevant `list/*.f` or `vrf/list/fl_*.f` — compilation in this framework is filelist-driven, not directory-scanned, so a file that exists on disk but isn't listed is silently never compiled.
+5. Use the **vrf-workflow** skill to compile and run (`cd odve/comp/agents/<proto>/vrf/work/run && source sourceme && make aclean all run`), and again before committing/pushing (analyze/compile checks, then `./regress.py submit`).
+
+## Naming convention reference (for manual edits too, not just scaffolding)
+
+- Files and classes: `odve_<proto>_<role>.sv` containing `class odve_<proto>_<role>`. Package files: `odve_<proto>_<group>_pkg.sv` containing `package odve_<proto>_<group>_pkg` (spelled out fully — don't abbreviate to typos like `agant`, and don't use the `ocdve_` prefix apb has).
+- Directory roles mirror `axi`: `intf/` (interface), `src/item/` (sequence item + its pkg), `src/agent/` (cfg, sqr, agent, agent_pkg) with `mon/`, `mst/`, `slv/` subfolders for monitor/master-driver/slave-driver, `seq/` (sequences, once they exist), `list/` (agent-only filelists), `vrf/` (standalone TB: `dut/`, `list/`, `tb/{env,tests}`, `work/{common,run,mini,check}` + `rlist/*.list`).
+- Make targets are consistent across every agent because every `work/<variant>/Makefile` just `include`s `work/common/Makefile`, which `include`s the single shared `${ODVE}/script/common/common.mk`. Never redefine `atb`/`adut`/`auvm`/`elab`/`all`/`run` per agent — override variables (`FL_TB`, `TESTNAME`, etc.) in `work/common/Makefile` instead. See the `vrf-workflow` skill for what each target does.

--- a/.claude/skills/vrf-new-agent/scripts/new_agent.sh
+++ b/.claude/skills/vrf-new-agent/scripts/new_agent.sh
@@ -1,0 +1,527 @@
+#!/bin/bash
+# Scaffold a new odve UVM agent under comp/agents/<proto>, following the
+# axi agent's structure/naming convention (plain uvm_agent/uvm_driver/
+# uvm_monitor/uvm_sequencer — no ocdve_common_* layer).
+#
+# Usage: run from the open-dve repo root:
+#   .claude/skills/vrf-new-agent/scripts/new_agent.sh <proto>
+# e.g.:
+#   .claude/skills/vrf-new-agent/scripts/new_agent.sh spi
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <proto_lowercase>" >&2
+    exit 1
+fi
+
+PROTO="$1"
+if ! [[ "$PROTO" =~ ^[a-z][a-z0-9_]*$ ]]; then
+    echo "Error: <proto> must be lowercase, start with a letter (e.g. spi, ahb, uart2)" >&2
+    exit 1
+fi
+PROTO_UPPER=$(echo "$PROTO" | tr '[:lower:]' '[:upper:]')
+
+if [ ! -d "odve/comp/agents" ]; then
+    echo "Error: run this from the open-dve repo root (odve/comp/agents not found here)" >&2
+    exit 1
+fi
+
+AGENT="odve/comp/agents/$PROTO"
+if [ -e "$AGENT" ]; then
+    echo "Error: $AGENT already exists — pick a new protocol name or remove it first" >&2
+    exit 1
+fi
+
+echo "Scaffolding new agent '$PROTO' at $AGENT"
+
+mkdir -p "$AGENT"/{intf,list,src/item,src/agent/mst,src/agent/slv,src/agent/mon,seq,reg}
+mkdir -p "$AGENT"/vrf/{dut,list,tb/env,tb/tests,work/{common,run,mini,check,rlist}}
+
+# ---------------------------------------------------------------------------
+# intf/
+# ---------------------------------------------------------------------------
+cat > "$AGENT/intf/odve_${PROTO}_if.sv" <<EOF
+interface odve_${PROTO}_if #(
+    parameter int unsigned ADDR_W = 32,
+    parameter int unsigned DATA_W = 32
+) (
+    input logic clk,
+    input logic rst_n
+);
+    // TODO: add ${PROTO_UPPER} protocol signals here
+
+endinterface
+EOF
+
+# ---------------------------------------------------------------------------
+# src/item/
+# ---------------------------------------------------------------------------
+cat > "$AGENT/src/item/odve_${PROTO}_item.sv" <<EOF
+class odve_${PROTO}_item extends uvm_sequence_item;
+    \`uvm_object_utils(odve_${PROTO}_item)
+
+    // TODO: add transaction fields here
+
+    function new(string name = "odve_${PROTO}_item");
+        super.new(name);
+    endfunction
+endclass
+EOF
+
+cat > "$AGENT/src/item/odve_${PROTO}_item_pkg.sv" <<EOF
+\`ifndef ODVE_${PROTO_UPPER}_ITEM_PKG
+\`define ODVE_${PROTO_UPPER}_ITEM_PKG
+package odve_${PROTO}_item_pkg;
+    \`include "uvm_macros.svh"
+    import uvm_pkg::*;
+    \`include "odve_${PROTO}_item.sv"
+endpackage
+\`endif
+EOF
+
+# ---------------------------------------------------------------------------
+# src/agent/
+# ---------------------------------------------------------------------------
+cat > "$AGENT/src/agent/odve_${PROTO}_cfg.sv" <<EOF
+class odve_${PROTO}_cfg extends uvm_object;
+    \`uvm_object_utils(odve_${PROTO}_cfg)
+
+    bit is_master = 1;
+    virtual odve_${PROTO}_if vif;
+
+    function new(string name = "odve_${PROTO}_cfg");
+        super.new(name);
+    endfunction
+endclass
+EOF
+
+cat > "$AGENT/src/agent/odve_${PROTO}_sqr.sv" <<EOF
+class odve_${PROTO}_sqr extends uvm_sequencer #(odve_${PROTO}_item);
+    \`uvm_component_utils(odve_${PROTO}_sqr)
+
+    function new(string name = "odve_${PROTO}_sqr", uvm_component parent = null);
+        super.new(name, parent);
+    endfunction
+endclass
+EOF
+
+cat > "$AGENT/src/agent/mon/odve_${PROTO}_mon.sv" <<EOF
+class odve_${PROTO}_mon extends uvm_monitor;
+    \`uvm_component_utils(odve_${PROTO}_mon)
+
+    uvm_analysis_port #(odve_${PROTO}_item) item_collected_port;
+    virtual odve_${PROTO}_if vif;
+
+    function new(string name = "odve_${PROTO}_mon", uvm_component parent = null);
+        super.new(name, parent);
+    endfunction
+
+    virtual function void build_phase(uvm_phase phase);
+        super.build_phase(phase);
+        item_collected_port = new("item_collected_port", this);
+    endfunction
+
+    virtual task run_phase(uvm_phase phase);
+        // TODO: sample vif and item_collected_port.write(tr) per transaction
+    endtask
+endclass
+EOF
+
+cat > "$AGENT/src/agent/mst/odve_${PROTO}_mst_drv_base.sv" <<EOF
+class odve_${PROTO}_mst_drv_base extends uvm_driver #(odve_${PROTO}_item);
+    \`uvm_component_utils(odve_${PROTO}_mst_drv_base)
+
+    virtual odve_${PROTO}_if vif;
+
+    function new(string name = "odve_${PROTO}_mst_drv_base", uvm_component parent = null);
+        super.new(name, parent);
+    endfunction
+
+    virtual task run_phase(uvm_phase phase);
+        forever begin
+            seq_item_port.get_next_item(req);
+            // TODO: drive vif from req
+            seq_item_port.item_done();
+        end
+    endtask
+endclass
+EOF
+
+cat > "$AGENT/src/agent/slv/odve_${PROTO}_slv_drv.sv" <<EOF
+class odve_${PROTO}_slv_drv extends uvm_driver #(odve_${PROTO}_item);
+    \`uvm_component_utils(odve_${PROTO}_slv_drv)
+
+    virtual odve_${PROTO}_if vif;
+
+    function new(string name = "odve_${PROTO}_slv_drv", uvm_component parent = null);
+        super.new(name, parent);
+    endfunction
+
+    virtual task run_phase(uvm_phase phase);
+        forever begin
+            seq_item_port.get_next_item(req);
+            // TODO: respond on vif per req
+            seq_item_port.item_done();
+        end
+    endtask
+endclass
+EOF
+
+cat > "$AGENT/src/agent/odve_${PROTO}_agent.sv" <<EOF
+class odve_${PROTO}_agent extends uvm_agent;
+    \`uvm_component_utils(odve_${PROTO}_agent)
+
+    odve_${PROTO}_cfg          cfg;
+    odve_${PROTO}_sqr          sqr;
+    odve_${PROTO}_mon          mon;
+    odve_${PROTO}_mst_drv_base drv;
+
+    function new(string name = "odve_${PROTO}_agent", uvm_component parent = null);
+        super.new(name, parent);
+    endfunction
+
+    virtual function void build_phase(uvm_phase phase);
+        super.build_phase(phase);
+        if (!uvm_config_db#(odve_${PROTO}_cfg)::get(this, "", "cfg", cfg)) begin
+            \`uvm_fatal(get_name(), "No config object")
+        end
+        mon = odve_${PROTO}_mon::type_id::create("mon", this);
+        if (get_is_active() == UVM_ACTIVE) begin
+            sqr = odve_${PROTO}_sqr::type_id::create("sqr", this);
+            drv = odve_${PROTO}_mst_drv_base::type_id::create("drv", this);
+        end
+    endfunction
+
+    virtual function void connect_phase(uvm_phase phase);
+        super.connect_phase(phase);
+        mon.vif = cfg.vif;
+        if (get_is_active() == UVM_ACTIVE) begin
+            drv.vif = cfg.vif;
+            drv.seq_item_port.connect(sqr.seq_item_export);
+        end
+    endfunction
+endclass
+EOF
+
+cat > "$AGENT/src/agent/odve_${PROTO}_agent_pkg.sv" <<EOF
+\`ifndef ODVE_${PROTO_UPPER}_AGENT_PKG
+\`define ODVE_${PROTO_UPPER}_AGENT_PKG
+package odve_${PROTO}_agent_pkg;
+    \`include "uvm_macros.svh"
+    import uvm_pkg::*;
+    import odve_${PROTO}_item_pkg::*;
+
+    \`include "odve_${PROTO}_cfg.sv"
+    \`include "mon/odve_${PROTO}_mon.sv"
+    \`include "mst/odve_${PROTO}_mst_drv_base.sv"
+    \`include "slv/odve_${PROTO}_slv_drv.sv"
+    \`include "odve_${PROTO}_sqr.sv"
+    \`include "odve_${PROTO}_agent.sv"
+endpackage
+\`endif
+EOF
+
+# ---------------------------------------------------------------------------
+# list/ (agent compile filelists)
+# ---------------------------------------------------------------------------
+cat > "$AGENT/list/agent.f" <<EOF
++incdir+\${ODVE}/comp/agents/${PROTO}/src/item
++incdir+\${ODVE}/comp/agents/${PROTO}/src/agent
++incdir+\${ODVE}/comp/agents/${PROTO}/src/agent/mon
++incdir+\${ODVE}/comp/agents/${PROTO}/src/agent/mst
++incdir+\${ODVE}/comp/agents/${PROTO}/src/agent/slv
+\${ODVE}/comp/agents/${PROTO}/intf/odve_${PROTO}_if.sv
+\${ODVE}/comp/agents/${PROTO}/src/item/odve_${PROTO}_item_pkg.sv
+\${ODVE}/comp/agents/${PROTO}/src/agent/odve_${PROTO}_agent_pkg.sv
+EOF
+
+cat > "$AGENT/list/item.f" <<EOF
++incdir+\${ODVE}/comp/agents/${PROTO}/src/item
+\${ODVE}/comp/agents/${PROTO}/src/item/odve_${PROTO}_item_pkg.sv
+EOF
+
+: > "$AGENT/list/seq.f"
+
+# ---------------------------------------------------------------------------
+# vrf/dut, vrf/list
+# ---------------------------------------------------------------------------
+cat > "$AGENT/vrf/dut/dut.sv" <<EOF
+module dut (
+    input clk, rst
+);
+
+    initial repeat (1) \$display ("Hi from DUT");
+endmodule
+EOF
+
+cat > "$AGENT/vrf/list/fl_tb.f" <<EOF
+-f \${ODVE}/comp/agents/${PROTO}/list/agent.f
+
++incdir+\${ODVE_UVM}/src/
++incdir+\${ODVE}/comp/agents/${PROTO}/vrf/tb/env/
+
+\${ODVE}/comp/agents/${PROTO}/vrf/tb/env/env_pkg.sv
+\${ODVE}/comp/agents/${PROTO}/vrf/tb/tests/test_pkg.sv
+
+\${ODVE}/comp/agents/${PROTO}/vrf/tb/top.sv
+EOF
+
+cat > "$AGENT/vrf/list/fl_dut.f" <<EOF
+\${ODVE}/comp/agents/${PROTO}/vrf/dut/dut.sv
+EOF
+
+cat > "$AGENT/vrf/list/fl_uvm.f" <<EOF
++incdir+\${ODVE_UVM}/src/
+\${ODVE_UVM}/src/uvm_macros.svh
+\${ODVE_UVM}/src/uvm_pkg.sv
+EOF
+
+# ---------------------------------------------------------------------------
+# vrf/tb/env
+# ---------------------------------------------------------------------------
+cat > "$AGENT/vrf/tb/env/cc.sv" <<'EOF'
+class cc extends uvm_component;
+    `uvm_component_utils(cc)
+
+    function new(string name = "cc", uvm_component parent = null);
+        super.new(name, parent);
+    endfunction
+
+    virtual function void build_phase(uvm_phase phase);
+        super.build_phase(phase);
+    endfunction
+
+    virtual function void connect_phase(uvm_phase phase);
+        super.connect_phase(phase);
+    endfunction
+endclass : cc
+EOF
+
+cat > "$AGENT/vrf/tb/env/scb.sv" <<'EOF'
+class scb extends uvm_component;
+    `uvm_component_utils(scb)
+
+    function new(string name = "scb", uvm_component parent = null);
+        super.new(name, parent);
+    endfunction
+
+    virtual function void build_phase(uvm_phase phase);
+        super.build_phase(phase);
+    endfunction
+
+    virtual function void connect_phase(uvm_phase phase);
+        super.connect_phase(phase);
+    endfunction
+endclass : scb
+EOF
+
+cat > "$AGENT/vrf/tb/env/env.sv" <<'EOF'
+class env extends uvm_env;
+    `uvm_component_utils(env)
+    cc  cc_o;
+    scb scb_o;
+
+    function new(string name = "env", uvm_component parent = null);
+        super.new(name, parent);
+    endfunction
+
+    virtual function void build_phase(uvm_phase phase);
+        super.build_phase(phase);
+        cc_o  = cc::type_id::create("cc_o", this);
+        scb_o = scb::type_id::create("scb_o", this);
+    endfunction
+
+    virtual function void connect_phase(uvm_phase phase);
+        super.connect_phase(phase);
+    endfunction
+endclass : env
+EOF
+
+cat > "$AGENT/vrf/tb/env/env_pkg.sv" <<'EOF'
+package env_pkg;
+    `include "uvm_macros.svh"
+    import uvm_pkg::*;
+
+    `include "cc.sv"
+    `include "scb.sv"
+    `include "env.sv"
+endpackage : env_pkg
+EOF
+
+# ---------------------------------------------------------------------------
+# vrf/tb/tests
+# ---------------------------------------------------------------------------
+cat > "$AGENT/vrf/tb/tests/base_test.sv" <<'EOF'
+class base_test extends uvm_test;
+    `uvm_component_utils(base_test)
+
+    env env_o;
+
+    function new(string name = "base_test", uvm_component parent = null);
+        super.new(name, parent);
+    endfunction : new
+
+    virtual function void build_phase(uvm_phase phase);
+        super.build_phase(phase);
+        env_o = env::type_id::create("env_o", this);
+    endfunction : build_phase
+endclass : base_test
+EOF
+
+cat > "$AGENT/vrf/tb/tests/simple_test.sv" <<'EOF'
+class simple_test extends base_test;
+    `uvm_component_utils(simple_test)
+
+    function new(string name = "simple_test", uvm_component parent = null);
+        super.new(name, parent);
+    endfunction : new
+
+    virtual task run_phase(uvm_phase phase);
+        super.run_phase(phase);
+        `uvm_info(get_name(), "RUN SIMPLE TEST", UVM_NONE)
+    endtask : run_phase
+endclass : simple_test
+EOF
+
+cat > "$AGENT/vrf/tb/tests/test_pkg.sv" <<'EOF'
+`ifndef __TEST_PKG_SV
+`define __TEST_PKG_SV
+
+package test_pkg;
+    `include "uvm_macros.svh"
+    import uvm_pkg::*;
+    import env_pkg::*;
+
+    `include "base_test.sv"
+    `include "simple_test.sv"
+endpackage
+
+`endif
+EOF
+
+cat > "$AGENT/vrf/tb/top.sv" <<EOF
+module top;
+    import uvm_pkg::*;
+    import test_pkg::*;
+
+    odve_${PROTO}_if odve_${PROTO}_if ();
+
+    initial repeat (1) \$display ("Hello From TB");
+    initial begin
+        uvm_config_db #(uvm_object_wrapper)::set(null, "*", "uvm_test_top", simple_test::type_id::get());
+        run_test("simple_test");
+    end
+endmodule
+EOF
+
+# ---------------------------------------------------------------------------
+# vrf/work/{common,run,mini,check}
+# ---------------------------------------------------------------------------
+cat > "$AGENT/vrf/work/common/sourceme" <<'EOF'
+#!/bin/bash
+export ODVE=$(readlink -f "../../../../../../")
+source $ODVE/script/source/common_sourceme
+EOF
+
+cat > "$AGENT/vrf/work/common/Makefile" <<'EOF'
+#Please go to this folder to edit local regression settings.
+
+DEF=
+
+RUN_OPTS += -batch
+
+COMP_OPTS+=
+
+COV_OPTS+=
+
+MAKE_RUN_OPTS+=
+
+TESTNAME?=simple_test
+
+DUMP=
+
+DUMP_TRAN=
+
+COV=
+
+UVM=
+
+COMP_CMD=
+
+RUN_CMD=
+
+COV_CMD=
+
+include ${ODVE}/script/common/common.mk
+EOF
+
+for variant in run check mini; do
+    cat > "$AGENT/vrf/work/$variant/sourceme" <<'EOF'
+#!/bin/bash
+source ./../common/sourceme
+EOF
+    cat > "$AGENT/vrf/work/$variant/Makefile" <<'EOF'
+#Please go to common folder to edit local regression settings.
+include ./../common/Makefile
+EOF
+    cat > "$AGENT/vrf/work/$variant/regress.py" <<'EOF'
+#!python
+import subprocess
+import sys
+import os
+odve=os.environ["ODVE"]
+subprocess.call(["python", f"{odve}/script/regress/regress.py"] + sys.argv[1:])
+EOF
+    chmod +x "$AGENT/vrf/work/$variant/sourceme" "$AGENT/vrf/work/$variant/regress.py"
+done
+chmod +x "$AGENT/vrf/work/common/sourceme"
+
+# ---------------------------------------------------------------------------
+# vrf/work/rlist
+# ---------------------------------------------------------------------------
+for list in mini check submit; do
+    cat > "$AGENT/vrf/work/rlist/$list.list" <<'EOF'
+run_name1 : TESTNAME=simple_test COMP_DIR=d1
+EOF
+done
+
+# ---------------------------------------------------------------------------
+# READMEs
+# ---------------------------------------------------------------------------
+cat > "$AGENT/README" <<EOF
+# odve ${PROTO_UPPER} agent
+
+TODO: describe the ${PROTO_UPPER} agent (scaffolded by vrf-new-agent).
+EOF
+
+cat > "$AGENT/vrf/README.md" <<'EOF'
+# How to run compilation
+
+```bash
+source sourceme
+make clean
+make all
+make run
+#or
+make clean all run
+```
+
+## TB Folder structure
+- dut - example DUT for compilation
+- tb  - example TB with agent instantiation and DUT connection
+- work - folder to build/run simulation and regression
+- list - TB filelists (fl_tb.f, fl_dut.f, fl_uvm.f)
+EOF
+
+echo "Done. Created:"
+find "$AGENT" -type f | sort
+
+cat <<EOF
+
+Next steps:
+1. Fill in odve_${PROTO}_if.sv with real ${PROTO_UPPER} signals.
+2. Fill in odve_${PROTO}_item.sv with real transaction fields.
+3. Implement the driver(s)/monitor logic (marked TODO).
+4. If you add more .sv files, add them to list/*.f or vrf/list/fl_*.f — compilation is filelist-driven, not directory-scanned.
+5. Compile/run with the vrf-workflow skill: cd odve/comp/agents/${PROTO}/vrf/work/run && source sourceme && make aclean all run.
+EOF

--- a/.claude/skills/vrf-workflow/SKILL.md
+++ b/.claude/skills/vrf-workflow/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: vrf-workflow
+description: Compile and simulate UVM/SystemVerilog agent code with Questa/ModelSim after editing files under odve/comp/agents/*/src, intf, item, seq, or vrf, and gate git commit/push on it. Use this proactively any time you modify, add, or remove a .sv file under odve/comp/agents/ (agent sources, interfaces, sequences, testbench env/tests, DUT) to confirm the change still compiles and the relevant test(s) still pass — do not report SystemVerilog edits as done without running this. ALWAYS use this before running `git commit` (analyze + compile must be clean) or `git push` (submit regression must be clean) on SystemVerilog changes in this repo. Also use when the user asks to "compile", "run a test", "check compilation", "run regression", or "run submit/check/mini" for an agent. Also applies if editing shared framework code under odve/script or odve/comp/common — re-run this for at least one agent (e.g. apb) to confirm the shared change didn't break the build.
+---
+
+# VRF compile / run / regress workflow
+
+This repo's verification agents are Questa/ModelSim UVM environments where **compilation is filelist-driven, not directory-scanned**. Editing or adding a `.sv` file is not enough by itself — you must also (a) make sure it's referenced by the right filelist if it's new, and (b) actually run the build to know whether it compiles. There is no separate "syntax check" step; compiling *is* the check.
+
+## 0. Find the right agent and work folder
+
+Each agent lives at `odve/comp/agents/<agent>/` (`apb` is the most complete and currently the only one with a working `vrf/` environment set up — check before assuming another agent like `ahb`/`jtag`/`spi`/`uart` has one yet). Its standalone verification environment is `odve/comp/agents/<agent>/vrf/`, and the build/run/regress workspace is `odve/comp/agents/<agent>/vrf/work/<variant>/`, where `<variant>` is one of:
+
+- `run/` — everyday compile + simulate loop while iterating on code.
+- `check/` or `submit/` — full regression, run before pushing.
+- `mini/` — a smaller/faster regression subset.
+- `common/` — not run directly; holds the shared `Makefile`/`sourceme` the other variants include.
+
+If a change is only in `odve/script/` or `odve/comp/common/` (shared framework code, not agent-specific), still run this workflow for at least one agent afterward — those files are `include`d by every agent's build.
+
+## 1. Source the environment (once per shell)
+
+```bash
+cd odve/comp/agents/<agent>/vrf/work/<variant>
+source sourceme
+```
+
+This exports `ODVE`, `ODVE_<AGENT>`, and `PROJ` as absolute paths and pulls in `odve/script/source/common_sourceme` (sets `ODVE_UVM`, locates `MS_HOME` from `vsim` on `PATH`). If `vsim` isn't on `PATH` in this environment, `sourceme`/`make` will fail early — tell the user Questa/ModelSim isn't available rather than guessing at results.
+
+## 2. Compile
+
+```bash
+make all
+```
+
+This runs `prework preuvm auvm uvm_dpi predut adut pretb atb elib` — compiles UVM, DUT, and TB into separate Questa libraries (`vlog`), then elaborates (`vopt`). **Read the actual output**, don't assume success from exit code alone: each `vlog`/`vopt` step prints a summary line like `Errors: 0, Warnings: 2` — any nonzero error count is a real compile failure to fix before moving on.
+
+`auvm`/`adut`/`atb` are Questa's **analyze** steps — they run `vlog` (which "analyzes" HDL into a library) for the UVM, DUT, and TB layers respectively, and can be run individually if you only touched one layer (e.g. `make atb` after a testbench-only change). `elib`/`elab` is the separate **elaborate** step (`vopt`) that links the analyzed libraries together. A source file can analyze cleanly on its own yet still fail to elaborate (e.g. a missing class reference across packages) — `make all` (or the narrower `make <layer> elib`) is what proves both, so don't treat "analyze passed" alone as "compilation is ok."
+
+If you added or removed a source file (not just edited an existing one), first check it's listed in the right filelist — otherwise it silently won't be compiled (or `vlog` will complain about a missing file):
+- Agent-side files (`src/`, `item/`, `seq/`, `intf/`) → `odve/comp/agents/<agent>/list/*.f` (`agent.f`, `item.f`, `seq.f`).
+- Testbench-side files (`vrf/tb/`, `vrf/dut/`) → `odve/comp/agents/<agent>/vrf/list/fl_tb.f` or `fl_dut.f`.
+
+If you changed the interface used elsewhere or touched shared framework code (`odve/script/common/common.mk`, `odve/comp/common/`), run a clean rebuild instead of an incremental one:
+
+```bash
+make aclean all
+```
+
+## 3. Run a specific test
+
+```bash
+make TESTNAME=<test_name> run
+```
+
+`<test_name>` is a UVM test class from `vrf/tb/tests/` (e.g. `read_test`, `write_test`, `simple_test`; default is `base_test`). This invokes `vsim` with `+UVM_TESTNAME=$(TESTNAME)` and writes `run.log` under the run directory (`$(TESTNAME)__run/` by default). **Check the log's UVM report summary** (the `UVM_ERROR :` / `UVM_FATAL :` counts near the end) — a test can finish without a Questa error yet still have failed inside UVM.
+
+Combine compile + run in one step during iteration:
+
+```bash
+make aclean all run TESTNAME=<test_name>
+```
+
+## 4. Run the full regression before pushing
+
+Every `work/<variant>` folder (`run/`, `mini/`, and `check/` where it exists) has its own `regress.py`/`sourceme` — you don't need a dedicated folder per list name, the list name is just an argument:
+
+```bash
+cd odve/comp/agents/<agent>/vrf/work/run   # any variant folder works
+source sourceme
+./regress.py submit
+```
+
+`regress.py <name>` reads `work/rlist/<name>.list` (each line names a run with its own `TESTNAME`/`COMP_DIR`/`RUN_OPTS` overrides) and drives `odve/script/regress/regress.py`, which runs the jobs in parallel (default up to 4 at once). `submit` is the pre-push regression list (`work/rlist/submit.list`, alongside `mini.list`); confirm which list name the user means if unclear, and don't invent a new list name without checking `work/rlist/` first.
+
+If a change touched `odve/script/regress/` itself (`regress.py`, `readlist.py`, `list2json.py`, `jobrunner.py`), test it against a real agent's `rlist/*.list` (e.g. `apb`) rather than reasoning about it in the abstract.
+
+## 5. Gate on git commit and push
+
+This is a hard sequence, not a suggestion — SystemVerilog changes are silently broken far more often than software changes, because there's no compiler running in the editor and no type system catching mistakes until `vlog` runs. Never skip a step because "it's a small change." This applies to changes under `odve/comp/agents/` and to shared framework changes under `odve/script/` or `odve/comp/common/` (verify against a real agent, e.g. `apb`).
+
+**Before `git commit`** (any commit touching `.sv`/`.f`/`Makefile` files):
+1. Run analyze on whatever layer(s) changed — `make atb` for testbench-only edits, `make adut` for DUT edits, `make auvm` if UVM library config changed, or just `make auvm adut atb` for all three. Fix every nonzero `Errors:` count.
+2. Run `make all` (which includes `elib`) to confirm it elaborates too — analyze-clean doesn't mean elaborate-clean (see step 2). Only commit once this is clean.
+
+**Before `git push`**:
+3. Run the `submit` regression (step 4 above): `./regress.py submit` from a `work/<variant>` folder. Read the results for every job in the list, not just the last one — confirm each ran and passed (no `UVM_ERROR`/`UVM_FATAL`, no Questa `Errors:` > 0). If any job fails, fix it and re-run the full list before pushing; don't push on a partial regression.
+
+If asked to commit/push and you haven't just run this sequence in the current conversation, run it first — don't rely on an earlier compile from before the latest edits.
+
+## After running
+
+Summarize what you ran (compile-only vs. specific test vs. regression), the pass/fail result from the log, and — if it failed — quote the specific error/UVM_ERROR lines rather than just saying "it failed." If compilation or simulation couldn't run at all (e.g. `vsim` missing), say so explicitly instead of reporting success.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,92 @@
+# AGENTS.md
+
+This file provides guidance to AI coding agents (Claude Code, Codex, etc.) when working with code in this repository.
+
+## What this repo is
+
+`open-dve` is a UVM/SystemVerilog verification framework ("Open Design Verification Environment") that unifies testbench compilation, running, and regression across multiple agents/VIPs (APB, AHB, AXI, PCIe, NVMe, MPHY, UNIPRO, UFS — per the roadmap in `README.md`; several are still placeholders). Its content lives under `odve/` (this repo is consumed as the `odve` git submodule by downstream repos such as `amba-axi`, where it's checked out at `<downstream>/odve`).
+
+Targets Mentor/Siemens **Questa/ModelSim** (`vlog`/`vsim`/`vmap`/`vlib`) as the primary simulator; Verilator support exists but is currently disabled in `script/source/common_sourceme`. See `README.md` for Questa/Verilator toolchain install prerequisites (make, python3, bash, readlink, and — for Verilator on Windows — Cygwin, gcc-g++ 10+, flex, bison, autoconf).
+
+## Commands
+
+All commands assume a Bash shell (Git Bash on Windows) with `make`, `python3`, `readlink`, and Questa/ModelSim's `vsim` on `PATH`.
+
+### Build and run an agent's verification environment (example: APB)
+
+```bash
+cd odve/comp/agents/apb/vrf/work/run
+source sourceme
+make aclean all run
+```
+
+- `sourceme` exports `ODVE`, the agent-specific path var (e.g. `ODVE_APB`), and `PROJ` as absolute paths, then sources `script/source/common_sourceme`, which sets `ODVE_UVM` (defaults to the vendored `uvm/uvm-1.1d/`; `uvm/1800.2-2020-2.0/` is available but commented out) and locates `MS_HOME` from `vsim` on `PATH`.
+- `make all` runs `prework preuvm auvm uvm_dpi predut adut pretb atb elib` — compiles UVM, DUT, and TB into **separate Questa libraries** (`work/uvm`, `work/dut`, `work/tb`), then elaborates with `vopt ... -L dut -L uvm`.
+- `make run` invokes `vsim tb.$(TOP) ... +UVM_TESTNAME=$(TESTNAME)` (default `TESTNAME=base_test`; override with `make TESTNAME=<name> run`).
+- `make clean`/`make aclean` remove build artifacts; `make rclean` removes `*__run` result directories.
+- Each agent's `vrf/work/<variant>/Makefile` (`run`, `check`, `mini`, `common`) `include`s `work/common/Makefile`, which includes the single shared `script/common/common.mk` used by every agent. Prefer changing `script/common/common.mk` for framework-wide build/run behavior, and an agent's `work/common/Makefile` for agent-local overrides.
+
+### Run a regression list
+
+```bash
+cd odve/comp/agents/apb/vrf/work/<variant>   # e.g. mini
+source sourceme
+./regress.py <list-name>                     # reads ../rlist/<list-name>.list
+```
+
+`regress.py` (per-agent copy, thin wrapper) forwards to `script/regress/regress.py`, which:
+- parses `../rlist/<list-name>.list` via `readlist.py` (each line names a run with `TESTNAME`/`COMP_DIR`/`RUN_OPTS` overrides, e.g. `run_name1 : TESTNAME=t1 COMP_DIR=d2 RUN_OPTS+='+arg1=1'`),
+- converts it to job commands via `list2json.py`,
+- executes jobs in parallel via `jobrunner.py` (`-max_jobs`, default 4).
+
+`script/regress/example.list` and `script/regress/comp.cfg` are references for the list/config format. Any `work/<variant>` folder has its own `regress.py`/`sourceme`, so the list name doesn't need to match the folder — e.g. `apb`'s `work/rlist/submit.list` (pre-push regression, run as `./regress.py submit` from `work/run` or `work/mini`) sits alongside `mini.list`.
+
+## Architecture
+
+### Repo layout (under `odve/`)
+
+- `comp/agents/<protocol>/` — one UVM agent per protocol: `apb`, `axi`, `ahb`, `jtag`, `spi`, `uart`. **`apb` is the most complete and is the best reference implementation** to copy patterns from when building out another agent.
+- `comp/common/` — shared base classes (`base/odve_common_base_item.sv`) and macros (`macro/odve_macro.sv`, e.g. `` `odve_rand(obj) `` calls `obj.user_randomize()`).
+- `script/common/common.mk` — the single shared Make include behind every agent's `vrf/work/*/Makefile`. Defines the `prework/preuvm/auvm/predut/adut/pretb/atb/elib/run/clean/rclean/aclean` targets and the `FL_TB`/`FL_UVM`/`FL_DUT`/`TOP`/`TESTNAME`/`RUN_DIR`/`COMP_DIR` variables.
+- `script/source/common_sourceme` — sets `ODVE_UVM` and locates the Questa install (`MS_HOME`) from `vsim` on `PATH`. Verilator env vars are present but commented out.
+- `script/regress/` — the regression runner: `regress.py` (entry point), `readlist.py` (parses `*.list` files), `list2json.py` (converts parsed runs to job commands), `jobrunner.py` (parallel job execution), `list2json.py`.
+- `script/schedule/`, `script/pdf/pdf2req/` — scheduling and requirements-doc tooling (early/placeholder).
+- `uvm/` — vendored UVM library sources: `uvm-1.1d` (default, per `common_sourceme`) and `1800.2-2020-2.0` (available, not default). Used instead of relying on a simulator-provided UVM.
+- `vip/` — placeholders for larger VIPs (`pcie`, `nvme`) mentioned in the README's roadmap; not yet implemented.
+
+### Per-agent structure (same shape in every `comp/agents/<protocol>/`, most complete in `apb`)
+
+- `intf/` — SystemVerilog interface(s) (e.g. `odve_apb_if.sv`, plus a plain `apb_if.sv`).
+- `src/` — the UVM component sources: `<proto>_agent.sv`, `<proto>_agent_cfg.sv`, `<proto>_agent_pkg.sv` (aggregates `` `include ``s), `<proto>_driver_base.sv` + master/slave driver specializations, `<proto>_monitor.sv`.
+- `item/` — the sequence item class(es) (e.g. `ocdve_apb_seq_item.sv`).
+- `seq/` — reusable sequences built on the item (e.g. `odve_apb_read_seq.sv`, `odve_apb_write_seq.sv`) plus a `seq_lib_pkg.sv` aggregator.
+- `reg/` — register-layer artifacts (scaffolding only in most agents).
+- `list/` — compile filelists for the agent itself: `agent.f` (full agent incl. `+incdir`s), `item.f` (item package only), `seq.f`.
+- `vrf/` — the agent's own standalone verification environment used to test it in isolation:
+  - `dut/dut.sv` — a minimal example DUT.
+  - `tb/top.sv` — top module; sets the default UVM test via `uvm_config_db` and calls `run_test`.
+  - `tb/env/` — `env.sv` (top-level `uvm_env`), `cc.sv` (connectivity/config component), `scb.sv` (scoreboard), `env_pkg.sv`.
+  - `tb/tests/` — `base_test.sv` plus scenario tests (`read_test.sv`, `write_test.sv`, `simple_test.sv`), aggregated by `test_pkg.sv`.
+  - `list/fl_tb.f`, `fl_dut.f`, `fl_uvm.f` — separate filelists per compile step (TB, DUT, UVM), referenced by `common.mk`'s `FL_TB`/`FL_DUT`/`FL_UVM`.
+  - `work/` — the build/run/regress workspace: `common/` (shared Makefile+sourceme — edit here for shared settings), `run/`, `mini/` (thin variant wrappers), `rlist/*.list` (named regression run definitions).
+
+New source files must be added to the correct `list/*.f` (agent) or `vrf/list/fl_*.f` (TB) — compilation is filelist-driven, not directory-scanned.
+
+`apb` and `axi` currently disagree on structure/base classes (see the `vrf-new-agent` skill for the details and why `axi`'s plain-`uvm_*` pattern, not `apb`'s, is canonical going forward). When adding a **new** protocol agent, use the `vrf-new-agent` skill (`.claude/skills/vrf-new-agent/`), which scaffolds a working skeleton via `scripts/new_agent.sh <proto>` instead of hand-copying an existing agent.
+
+### Compilation model
+
+Questa compilation is split into separate libraries per layer — `uvm`, `dut`, `tb` — then linked at elaboration (`vopt ... -L dut -L uvm`) and simulated (`vsim tb.$(TOP) ...`). This is why a new file is invisible to the build until it's added to the right filelist.
+
+### Environment variable conventions
+
+- `ODVE` — absolute path to this framework's root (`odve/` inside this repo, or `<downstream>/odve/odve` when consumed as a submodule).
+- `ODVE_<PROTO>` (e.g. `ODVE_APB`, `ODVE_AXI`) — absolute path to that protocol's agent directory, used inside its own filelists via `${ODVE_<PROTO>}/...`.
+- `ODVE_UVM` — path to the vendored UVM library in use.
+- `PROJ` — absolute path to the current agent, used as the default `VRF` base (`$(PROJ)/vrf`) in `common.mk`.
+
+All of these are set by the relevant `sourceme` script — always `source sourceme` before running `make` in a `work/` directory.
+
+## Consumers
+
+Downstream repos (e.g. `amba-axi`) pull this repo in as a `odve` git submodule and build their own agent on top of `comp/common/` and `script/`. When changing shared scripts (`script/common/common.mk`, `script/source/common_sourceme`, `script/regress/*`), check for impact across all agents in `comp/agents/`, not just the one you're editing.

--- a/odve/comp/agents/apb/vrf/work/rlist/submit.list
+++ b/odve/comp/agents/apb/vrf/work/rlist/submit.list
@@ -1,0 +1,3 @@
+run_name1 : TESTNAME=t1 COMP_DIR=d2 RUN_OPTS+='+arg1=1'
+run_name2 : TESTNAME=t2 COMP_DIR=d1 RUN_OPTS+='+arg2=2'
+run_name3 : TESTNAME=t3 COMP_DIR=d1 RUN_OPTS+='+arg2=3'


### PR DESCRIPTION
Documents the framework's build/run/regress workflow, env var conventions, and per-agent structure for future AI agents. Adds a skill that auto-compiles/simulates after SystemVerilog edits and gates git commit/push on analyze+compile and submit-regression passing, plus a skill that scaffolds new protocol agents following axi's (not apb's, which references a nonexistent common-component base class) structure and naming convention. Also adds the submit regression list referenced by the workflow skill.