### PR TITLE
Fix regress.py to actually run its regression list, and populate apb'…

### DIFF
--- a/odve/comp/agents/apb/vrf/work/common/regress.py
+++ b/odve/comp/agents/apb/vrf/work/common/regress.py
@@ -3,4 +3,4 @@ import subprocess
 import sys
 import os
 odve=os.environ["ODVE"]
-subprocess.call(["python", f"{odve}/script/regress/regress.py"] + sys.argv[1:])
+sys.exit(subprocess.call(["python", f"{odve}/script/regress/regress.py"] + sys.argv[1:]))

--- a/odve/comp/agents/apb/vrf/work/mini/regress.py
+++ b/odve/comp/agents/apb/vrf/work/mini/regress.py
@@ -3,4 +3,4 @@ import subprocess
 import sys
 import os
 odve=os.environ["ODVE"]
-subprocess.call(["python", f"{odve}/script/regress/regress.py"] + sys.argv[1:])
+sys.exit(subprocess.call(["python", f"{odve}/script/regress/regress.py"] + sys.argv[1:]))

--- a/odve/comp/agents/apb/vrf/work/rlist/mini.list
+++ b/odve/comp/agents/apb/vrf/work/rlist/mini.list
@@ -1,3 +1,1 @@
-run_name1 : TESTNAME=t1 COMP_DIR=d2 RUN_OPTS+='+arg1=1'
-run_name2 : TESTNAME=t2 COMP_DIR=d1 RUN_OPTS+='+arg2=2'
-run_name3 : TESTNAME=t3 COMP_DIR=d1 RUN_OPTS+='+arg2=3'
+apb_read : TESTNAME=read_test

--- a/odve/comp/agents/apb/vrf/work/rlist/submit.list
+++ b/odve/comp/agents/apb/vrf/work/rlist/submit.list
@@ -1,3 +1,1 @@
-run_name1 : TESTNAME=t1 COMP_DIR=d2 RUN_OPTS+='+arg1=1'
-run_name2 : TESTNAME=t2 COMP_DIR=d1 RUN_OPTS+='+arg2=2'
-run_name3 : TESTNAME=t3 COMP_DIR=d1 RUN_OPTS+='+arg2=3'
+apb_read : TESTNAME=read_test

--- a/odve/comp/agents/apb/vrf/work/run/regress.py
+++ b/odve/comp/agents/apb/vrf/work/run/regress.py
@@ -3,4 +3,4 @@ import subprocess
 import sys
 import os
 odve=os.environ["ODVE"]
-subprocess.call(["python", f"{odve}/script/regress/regress.py"] + sys.argv[1:])
+sys.exit(subprocess.call(["python", f"{odve}/script/regress/regress.py"] + sys.argv[1:]))

--- a/odve/script/regress/jobrunner.py
+++ b/odve/script/regress/jobrunner.py
@@ -7,7 +7,8 @@ class JobRunner :
 
     def run_command(self, command):
         try:
-            result = subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+            result = subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                     universal_newlines=True, encoding="utf-8", errors="replace")
             output = result.stdout
             error = result.stderr
             return_code = result.returncode

--- a/odve/script/regress/regress.py
+++ b/odve/script/regress/regress.py
@@ -3,6 +3,22 @@ import sys
 import argparse
 import json
 import os
+import re
+
+
+def job_failed(result):
+    """A job's result string counts as failed if the process itself exited non-zero
+    (compile error, tool crash, ...), or -- since `vsim -batch` exits 0 even when the
+    simulated test hit UVM_ERROR/UVM_FATAL -- if its UVM report summary shows either
+    non-zero. A result with no UVM summary at all (e.g. the compile job, or vsim never
+    got that far) is judged on return code alone."""
+    if "Return code: 0" not in result:
+        return True
+    for sev in ("UVM_ERROR", "UVM_FATAL"):
+        m = re.search(sev + r"\s*:\s*(\d+)", result)
+        if m and int(m.group(1)) > 0:
+            return True
+    return False
 
 
 odve_name="ODVE"
@@ -29,10 +45,11 @@ def main():
     parser = argparse.ArgumentParser(description="Regression runner script by regress list")
     parser.add_argument("top_list", help="Regression list name")
     parser.add_argument("-opts", "--opts", help="Output JSON file")
-    parser.add_argument("-max_jobs", "--max_jobs", help="Output JSON file")
-    parser.add_argument("-no_comp", "--no_comp", help="Config JSON file")
+    parser.add_argument("-max_jobs", "--max_jobs", type=int, default=4, help="Max parallel jobs")
+    parser.add_argument("-no_comp", "--no_comp", action="store_true", help="Skip the compile step and run the list against the existing build")
 
     args = parser.parse_args()
+    maxj = args.max_jobs
 
     tlist=f"{cwd}/../rlist/{args.top_list}.list"
     print (f"file.list is : {tlist}")
@@ -44,17 +61,24 @@ def main():
     l2j = list2json ()
     cmdsj = l2j.convert2j(rf.getlines())
     print(json.dumps(cmdsj, indent=4))
-    cmdsl = l2j.gencmd(cmdsj) 
+    cmdsl = l2j.gencmd(cmdsj)
     print (cmdsl)
 
-    jc = JobRunner(maxj)
-    comp_jobs = ["make clean all"]
-    results=jc.run_jobs(comp_jobs)
-    print (results)
+    if not args.no_comp:
+        jc = JobRunner(maxj)
+        comp_jobs = ["make clean all"]
+        results=jc.run_jobs(comp_jobs)
+        print (results)
+        if any(job_failed(r) for r in results):
+            print("Compile failed (see output above) -- aborting regression run.")
+            exit(1)
 
-    #jr = JobRunner(maxj) 
-    #results=jr.run_jobs(cmdsl)
-    #print (results)
+    jr = JobRunner(maxj)
+    results=jr.run_jobs(cmdsl)
+    print (results)
+    if any(job_failed(r) for r in results):
+        print("One or more regression runs failed (see output above).")
+        exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…s lists

regress.py parsed each rlist entry into a `make run ...` command but never executed it - only `make clean all` ran, so `./regress.py <list>` silently did nothing beyond compiling regardless of the list's content. Also wire up `-max_jobs`/`-no_comp`, which were parsed but never applied.

Job pass/fail also can't rely on the subprocess return code alone: `vsim -batch` exits 0 even when the simulated test hit UVM_ERROR/UVM_FATAL (verified with a deliberately-bad TESTNAME). job_failed() now also checks the UVM report summary.

jobrunner.py's subprocess.run() decoded output using the system's default codepage, which crashed a reader thread on non-ASCII byte sequences in tool output; pin encoding=utf-8, errors=replace instead.

The three work/{run,mini,common}/regress.py wrappers never propagated the inner script's exit code via subprocess.call(), so `./regress.py <list>` always reported success regardless of failures - sys.exit() the result.

apb's mini.list/submit.list were still the unpopulated placeholder template (TESTNAME=t1/t2/t3, which don't exist); populated both with the one test that actually exists and compiles (read_test - test_pkg.sv doesn't even `include` write_test.sv/simple_test.sv). Verified end-to-end: both lists run clean (UVM_ERROR:0, UVM_FATAL:0) through the fixed regress.py.