### PR TITLE
Add Verilator (Docker) support to APB agent's vrf flow

### DIFF
--- a/odve/comp/agents/apb/intf/apb_if.sv
+++ b/odve/comp/agents/apb/intf/apb_if.sv
@@ -1,7 +1,7 @@
 interface apb_if (
-    wire clk,
-    wire we,
-    wire data
+    input wire clk,
+    input wire we,
+    output wire data
 );
 logic data_r;
 

--- a/odve/comp/agents/apb/vrf/list/fl.f
+++ b/odve/comp/agents/apb/vrf/list/fl.f
@@ -1,0 +1,3 @@
+-f ${ODVE}/comp/agents/apb/vrf/list/fl_uvm.f
+-f ${ODVE}/comp/agents/apb/vrf/list/fl_dut.f
+-f ${ODVE}/comp/agents/apb/vrf/list/fl_tb.f

--- a/odve/comp/agents/apb/vrf/list/fl_tb.f
+++ b/odve/comp/agents/apb/vrf/list/fl_tb.f
@@ -1,6 +1,7 @@
 -f ${ODVE}/comp/agents/apb/list/agent.f
 
 +incdir+${ODVE_UVM}/src/
++incdir+${ODVE}/comp/agents/apb/vrf/tb/tests/
 ${ODVE}/comp/agents/apb/vrf/tb/tests/test_pkg.sv
 
 ${ODVE}/comp/agents/apb/vrf/tb/top.sv

--- a/odve/comp/agents/apb/vrf/work/common/Makefile_veri
+++ b/odve/comp/agents/apb/vrf/work/common/Makefile_veri
@@ -1,0 +1,37 @@
+.PHONY: all run clean version
+
+VRF ?=$(PROJ)/vrf
+BIN=Vtop
+NPROC=4
+MODE ?= --binary
+ifndef TOP
+	TOP=top
+endif
+BUILD_OPTS = \
+	--timescale 1ns/1ps \
+	--cc \
+	$(MODE) \
+	--timing \
+	--vpi \
+	-Wno-fatal \
+	-O3 \
+	-j $(NPROC) \
+	-o $(BIN) \
+	--top-module $(TOP)
+
+# UVM's DPI shim (regex/cmdline/HDL-backdoor); linked in directly since
+# Verilator has no simulator-native equivalent to preload like Questa's
+# -sv_lib. --vpi above pulls in the vpi_* runtime it calls into.
+DPI_SRCS = ${ODVE_UVM}/src/dpi/uvm_dpi.cc
+
+clean:
+	rm -rf obj_dir
+
+all:
+	$(VERILATOR_ROOT)/bin/verilator $(BUILD_OPTS) -F $(VRF)/list/fl.f $(DPI_SRCS)
+
+run:
+	./obj_dir/$(BIN)
+
+version:
+	$(VERILATOR_ROOT)/bin/verilator --version

--- a/odve/comp/agents/apb/vrf/work/run/Makefile
+++ b/odve/comp/agents/apb/vrf/work/run/Makefile
@@ -1,2 +1,10 @@
 #PLease go to common folder to edit local regression settings.
-include ./../common/Makefile
+ifdef VERILATOR
+	VERI := 1
+endif
+
+ifndef VERI
+	include ./../common/Makefile
+else
+	include ./../common/Makefile_veri
+endif

--- a/odve/script/source/common_sourceme
+++ b/odve/script/source/common_sourceme
@@ -11,6 +11,11 @@ export MS_GCC_PATH="${MS_HOME}/gcc-4.2.1-mingw32vc12"
 export PATH="${MS_GCC_PATH}/bin:${PATH}"
 
 ##
+# Verilator: defaults to the Docker-wrapped install vendored in
+# script/verilator-docker/ (needs `docker` on PATH, nothing else).
+# Set VERILATOR_ROOT yourself beforehand (e.g. a native/Cygwin build) to
+# bypass Docker and use that instead.
 #export VERILATOR_ROOT=/home/viktor/verilator/verilator
 #export PATH="/cygdrive/c/cygwin64/bin:$PATH"
-#export PATH="$VERILATOR_ROOT/bin:$PATH"
+export VERILATOR_ROOT="${VERILATOR_ROOT:-${ODVE}/script/verilator-docker}"
+export PATH="$VERILATOR_ROOT/bin:$PATH"

--- a/odve/script/verilator-docker/bin/verilator
+++ b/odve/script/verilator-docker/bin/verilator
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Docker-backed Verilator, used as $(VERILATOR_ROOT)/bin/verilator by
+# vrf/work/common/Makefile_veri when no native Verilator install is on PATH.
+#
+# Mounts the repo root (derived from $ODVE, which every odve sourceme
+# script exports) at the identical path inside the container, so absolute
+# paths already used by this framework's filelists resolve unchanged, and
+# forwards ODVE/ODVE_UVM so the ${ODVE}-style expansion inside .f files
+# still works when verilator itself parses them.
+set -euo pipefail
+
+VERILATOR_DOCKER_IMAGE="${VERILATOR_DOCKER_IMAGE:-verilator/verilator:latest}"
+
+if [ -z "${ODVE:-}" ]; then
+    echo "verilator (docker wrapper): \$ODVE is not set - source sourceme first" >&2
+    exit 1
+fi
+
+REPO_ROOT="$(cd "$ODVE/.." && pwd)"
+
+exec docker run --rm \
+    -u "$(id -u):$(id -g)" \
+    -e ODVE \
+    -e ODVE_UVM \
+    -v "$REPO_ROOT:$REPO_ROOT" \
+    -w "$(pwd)" \
+    "$VERILATOR_DOCKER_IMAGE" \
+    "$@"


### PR DESCRIPTION
Wires `make ... VERILATOR=1` (or the existing `VERI=1`) into the same `Makefile_veri`/`VERI`-switch pattern already used by the uart agent, backed by a Dockerized Verilator so no native toolchain install is required.

## What changed

- `odve/script/verilator-docker/bin/verilator` (new) — Docker-backed `verilator` shim; mounts the repo at an identical path so `${ODVE}`-style filelist paths resolve unchanged.
- `odve/script/source/common_sourceme` — enables the previously commented-out `VERILATOR_ROOT`/`PATH` export, defaulting to the Docker wrapper (still overridable by presetting `VERILATOR_ROOT` for a native/Cygwin build).
- `odve/comp/agents/apb/vrf/list/fl.f` (new) + `odve/comp/agents/apb/vrf/work/common/Makefile_veri` (new) — APB Verilator build: `--binary --timing --vpi`, plus linking UVM's DPI shim `uvm_dpi.cc` (Questa loads it via `-sv_lib`; Verilator must link it directly).
- `odve/comp/agents/apb/vrf/work/run/Makefile` — `ifndef VERI` switch mirroring uart's, with `VERILATOR=1` accepted as an alias.

## Latent bug fixes

Both were already invalid regardless of simulator; Questa's more permissive defaults masked them:

- `apb_if.sv` — ports had no direction (`wire clk` → `input wire clk`).
- `fl_tb.f` — missing `+incdir+` for its own `tests/` dir (Questa implicitly searches an including file's directory, Verilator does not).

## Verification

`make clean all run VERILATOR=1` from `odve/comp/agents/apb/vrf/work/run` builds and runs the real UVM `read_test` end-to-end — UVM banner, `Hello From TB`, test phasing, clean report (0 errors / 0 fatals), exit 0. The legacy `VERI=1` spelling still works. Questa-only files (`work/common/Makefile`, `script/common/common.mk`) are untouched.

## Note

The APB agent's `src/` classes (driver/monitor/agent) reference an `ocdve_common_pkg` that does not exist anywhere in the repo and are not referenced by any filelist — they are dead code under either simulator today. This PR deliberately does not address that pre-existing gap; it wires Verilator into exactly the set Questa actually compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)