### PR TITLE
Add setup.sh to fetch the Verilator image, with OS and engine checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,37 @@ To run TB with Questa:
 - install bash for git
 - install tool readlink
 
-To run TB with Verilator 
+To run TB with Verilator
+
+## Recommended: containerised Verilator (docker or podman)
+
+No Verilator/gcc/flex/bison install needed - only a container engine.
+Works on WSL, native Linux, macOS and Git Bash on Windows.
+
+1. Download the Verilator image once:
+   ```bash
+   cd odve/script/verilator-docker
+   ./setup.sh
+   ```
+   It reports the detected OS and container engine, prints install
+   instructions if neither docker nor podman is present (`--install-engine`
+   installs podman for you on Linux/WSL), then pulls the image.
+
+2. Build and run:
+   ```bash
+   cd odve/comp/agents/apb/vrf/work/run
+   source sourceme
+   make clean all run VERILATOR=1
+   ```
+
+Offline machines (e.g. CAD hosts without internet) - on a connected
+machine run `docker save verilator/verilator:latest | gzip > verilator-image.tar.gz`,
+copy the file over, then `./setup.sh --load verilator-image.tar.gz`.
+
+See `odve/script/verilator-docker/README.md` for all options and
+environment variables.
+
+## Alternative: native Verilator install
 (https://veripool.org/guide/latest/install.html#installation)
 - Windows:
     - https://cygwin.com/install.html (follow description to install all packages)
@@ -52,3 +82,6 @@ To run TB with Verilator
     - Make sure that you provide VERILATOR_ROOT, 
     - Make sure that you added it to PATH
     - call `make clean all run VERI=1`
+
+  Setting `VERILATOR_ROOT` before `source sourceme` bypasses the container
+  wrapper and uses your native install instead.

--- a/odve/script/verilator-docker/README.md
+++ b/odve/script/verilator-docker/README.md
@@ -1,0 +1,76 @@
+# Containerised Verilator
+
+Runs Verilator from a container image so no native Verilator/gcc/flex/bison
+toolchain has to be installed on the host. Used by the agents' `VERILATOR=1`
+build path (`vrf/work/common/Makefile_veri`).
+
+Works with **docker** or **podman**, on **WSL**, **native Linux**, **macOS**,
+and **Git Bash on Windows** (WSL is the better-tested path on Windows).
+
+## First-time setup
+
+```bash
+./setup.sh
+```
+
+Checks the OS and container engine, then pulls `verilator/verilator:latest`
+(a few hundred MB, once). If no engine is installed it prints per-OS install
+instructions; `./setup.sh --install-engine` will install podman for you on
+Linux/WSL.
+
+Then build and run any agent that supports it:
+
+```bash
+cd $ODVE/comp/agents/apb/vrf/work/run
+source sourceme
+make clean all run VERILATOR=1
+```
+
+`sourceme` points `VERILATOR_ROOT` at this directory, so `bin/verilator`
+is picked up as the `verilator` binary automatically.
+
+## Offline / air-gapped hosts (e.g. CAD machines)
+
+On a machine **with** internet:
+
+```bash
+docker pull verilator/verilator:latest
+docker save verilator/verilator:latest | gzip > verilator-image.tar.gz
+```
+
+Copy `verilator-image.tar.gz` across, then on the offline machine:
+
+```bash
+./setup.sh --load verilator-image.tar.gz
+```
+
+Nothing contacts the network after that.
+
+## Options
+
+| Command | Effect |
+| --- | --- |
+| `./setup.sh` | check environment, pull image if missing |
+| `./setup.sh --check` | report only, change nothing (exit 1 if unusable) |
+| `./setup.sh --install-engine` | install podman if no engine is present |
+| `./setup.sh --load <tarball>` | load the image from a file instead of pulling |
+| `./setup.sh --image <ref>` | use a different image than the default |
+
+## Environment variables
+
+| Variable | Purpose |
+| --- | --- |
+| `VERILATOR_ROOT` | Set it **before** `source sourceme` to use a native Verilator install instead of this wrapper. |
+| `ODVE_CONTAINER_ENGINE` | Pin the engine (`docker` or `podman`). Default: docker if present, else podman. |
+| `VERILATOR_DOCKER_IMAGE` | Override the image reference. Default `verilator/verilator:latest`. |
+
+## How the wrapper works
+
+`bin/verilator` mounts the repo root at the **same absolute path** inside the
+container and sets the working directory to match, so the absolute paths in
+this framework's `.f` filelists resolve identically inside and out. `ODVE` and
+`ODVE_UVM` are forwarded so `${ODVE}`-style expansion inside filelists still
+works when Verilator parses them.
+
+Output files are written back as your own user (docker: `-u uid:gid`;
+rootless podman: `--userns=keep-id`), not as root.

--- a/odve/script/verilator-docker/bin/verilator
+++ b/odve/script/verilator-docker/bin/verilator
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Docker-backed Verilator, used as $(VERILATOR_ROOT)/bin/verilator by
+# Container-backed Verilator, used as $(VERILATOR_ROOT)/bin/verilator by
 # vrf/work/common/Makefile_veri when no native Verilator install is on PATH.
 #
 # Mounts the repo root (derived from $ODVE, which every odve sourceme
@@ -7,19 +7,41 @@
 # paths already used by this framework's filelists resolve unchanged, and
 # forwards ODVE/ODVE_UVM so the ${ODVE}-style expansion inside .f files
 # still works when verilator itself parses them.
+#
+# Run script/verilator-docker/setup.sh once first to fetch the image.
 set -euo pipefail
 
 VERILATOR_DOCKER_IMAGE="${VERILATOR_DOCKER_IMAGE:-verilator/verilator:latest}"
 
 if [ -z "${ODVE:-}" ]; then
-    echo "verilator (docker wrapper): \$ODVE is not set - source sourceme first" >&2
+    echo "verilator (container wrapper): \$ODVE is not set - source sourceme first" >&2
+    exit 1
+fi
+
+# docker unless told otherwise; podman is a drop-in alternative.
+ENGINE="${ODVE_CONTAINER_ENGINE:-}"
+if [ -z "$ENGINE" ]; then
+    for e in docker podman; do
+        if command -v "$e" >/dev/null 2>&1; then ENGINE="$e"; break; fi
+    done
+fi
+if [ -z "$ENGINE" ]; then
+    echo "verilator (container wrapper): neither docker nor podman on PATH." >&2
+    echo "  run ${ODVE}/script/verilator-docker/setup.sh for install instructions" >&2
     exit 1
 fi
 
 REPO_ROOT="$(cd "$ODVE/.." && pwd)"
 
-exec docker run --rm \
-    -u "$(id -u):$(id -g)" \
+# Rootless podman already maps the calling user onto the container user via
+# keep-id; docker needs to be told explicitly or it writes root-owned output.
+ID_OPTS=(-u "$(id -u):$(id -g)")
+if [ "$(basename "$ENGINE")" = "podman" ]; then
+    ID_OPTS=(--userns=keep-id)
+fi
+
+exec "$ENGINE" run --rm \
+    "${ID_OPTS[@]}" \
     -e ODVE \
     -e ODVE_UVM \
     -v "$REPO_ROOT:$REPO_ROOT" \

--- a/odve/script/verilator-docker/setup.sh
+++ b/odve/script/verilator-docker/setup.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# One-time setup for the containerised Verilator used by `make ... VERILATOR=1`.
+#
+# Detects the host OS and container engine, installs the engine if asked,
+# then pulls (or loads, for offline hosts) the Verilator image.
+#
+#   ./setup.sh                     check environment + pull the image
+#   ./setup.sh --check             check only, change nothing
+#   ./setup.sh --install-engine    also install docker/podman if missing
+#   ./setup.sh --load <tarball>    load image from a file instead of pulling
+#   ./setup.sh --image <ref>       use a different image than the default
+#
+# Exit codes: 0 ok, 1 environment not usable, 2 bad usage.
+set -euo pipefail
+
+IMAGE="${VERILATOR_DOCKER_IMAGE:-verilator/verilator:latest}"
+MODE=pull
+LOAD_FILE=""
+INSTALL_ENGINE=0
+
+RED=''; GRN=''; YLW=''; BLD=''; RST=''
+if [ -t 1 ]; then
+    RED=$'\033[31m'; GRN=$'\033[32m'; YLW=$'\033[33m'; BLD=$'\033[1m'; RST=$'\033[0m'
+fi
+ok()   { printf '%s[ ok ]%s %s\n'   "$GRN" "$RST" "$*"; }
+info() { printf '%s[info]%s %s\n'   ""     ""     "$*"; }
+warn() { printf '%s[warn]%s %s\n'   "$YLW" "$RST" "$*"; }
+err()  { printf '%s[fail]%s %s\n'   "$RED" "$RST" "$*" >&2; }
+hdr()  { printf '\n%s== %s ==%s\n'  "$BLD" "$*" "$RST"; }
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --check)          MODE=check ;;
+        --install-engine) INSTALL_ENGINE=1 ;;
+        --load)           MODE=load; LOAD_FILE="${2:-}"; shift
+                          [ -n "$LOAD_FILE" ] || { err "--load needs a file"; exit 2; } ;;
+        --image)          IMAGE="${2:-}"; shift
+                          [ -n "$IMAGE" ] || { err "--image needs a value"; exit 2; } ;;
+        -h|--help)        sed -n '2,13p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *)                err "unknown option: $1 (try --help)"; exit 2 ;;
+    esac
+    shift
+done
+
+# ---------------------------------------------------------------- OS detection
+
+OS_KIND=unknown       # wsl | linux | windows | macos
+OS_PRETTY="$(uname -s -r 2>/dev/null || echo unknown)"
+DISTRO=""
+PKG=""                # apt | dnf | yum | pacman | zypper
+
+detect_os() {
+    case "$(uname -s)" in
+        Linux)
+            if grep -qiE '(microsoft|wsl)' /proc/version 2>/dev/null || [ -n "${WSL_DISTRO_NAME:-}" ]; then
+                OS_KIND=wsl
+            else
+                OS_KIND=linux
+            fi
+            if [ -r /etc/os-release ]; then
+                # shellcheck disable=SC1091
+                DISTRO="$(. /etc/os-release && echo "${PRETTY_NAME:-$NAME}")"
+            fi
+            for c in apt-get dnf yum pacman zypper; do
+                if command -v "$c" >/dev/null 2>&1; then
+                    case "$c" in apt-get) PKG=apt ;; *) PKG="$c" ;; esac
+                    break
+                fi
+            done
+            ;;
+        Darwin)                      OS_KIND=macos ;;
+        MINGW*|MSYS*|CYGWIN*)        OS_KIND=windows ;;
+    esac
+}
+
+detect_os
+
+hdr "Host"
+case "$OS_KIND" in
+    wsl)
+        ok "WSL detected${WSL_DISTRO_NAME:+ (distro: $WSL_DISTRO_NAME)}"
+        [ -n "$DISTRO" ] && info "$DISTRO"
+        info "kernel: $OS_PRETTY"
+        info "Either Docker Desktop with WSL integration, or an engine installed"
+        info "inside this distro, will work."
+        ;;
+    linux)
+        ok "Native Linux detected"
+        [ -n "$DISTRO" ] && info "$DISTRO"
+        info "kernel: $OS_PRETTY"
+        ;;
+    windows)
+        ok "Windows shell detected (Git Bash / MSYS / Cygwin)"
+        info "$OS_PRETTY"
+        warn "Paths are translated by MSYS; if the build cannot find files, run"
+        warn "this flow from WSL instead - that is the better-tested path here."
+        ;;
+    macos)
+        ok "macOS detected ($OS_PRETTY)"
+        ;;
+    *)
+        warn "Unrecognised OS: $OS_PRETTY - continuing, but you are off the tested path."
+        ;;
+esac
+
+# --------------------------------------------------- container engine handling
+
+ENGINE=""
+
+find_engine() {
+    if [ -n "${ODVE_CONTAINER_ENGINE:-}" ]; then
+        if command -v "$ODVE_CONTAINER_ENGINE" >/dev/null 2>&1; then
+            ENGINE="$ODVE_CONTAINER_ENGINE"
+        else
+            warn "ODVE_CONTAINER_ENGINE=$ODVE_CONTAINER_ENGINE is set but not on PATH."
+        fi
+        return 0
+    fi
+    for e in docker podman; do
+        if command -v "$e" >/dev/null 2>&1; then ENGINE="$e"; return; fi
+    done
+}
+
+print_install_help() {
+    hdr "How to install a container engine"
+    case "$OS_KIND" in
+        wsl)
+            cat <<'EOF'
+Option A - Docker Desktop on Windows (simplest):
+  1. Install from https://www.docker.com/products/docker-desktop/
+  2. Settings -> Resources -> WSL integration -> enable for this distro
+  3. Reopen this shell, then re-run: ./setup.sh
+
+Option B - engine inside WSL (no Docker Desktop):
+  Docker:  curl -fsSL https://get.docker.com | sudo sh
+           sudo usermod -aG docker "$USER"     # then reopen the shell
+  Podman:  sudo apt-get update && sudo apt-get install -y podman
+EOF
+            ;;
+        linux)
+            case "$PKG" in
+                apt)    echo "  Docker: curl -fsSL https://get.docker.com | sudo sh"
+                        echo "          sudo usermod -aG docker \"\$USER\"   # then re-login"
+                        echo "  Podman: sudo apt-get update && sudo apt-get install -y podman" ;;
+                dnf)    echo "  Podman: sudo dnf install -y podman"
+                        echo "  Docker: sudo dnf install -y docker-ce docker-ce-cli containerd.io" ;;
+                yum)    echo "  Podman: sudo yum install -y podman" ;;
+                pacman) echo "  Docker: sudo pacman -S docker    Podman: sudo pacman -S podman" ;;
+                zypper) echo "  Podman: sudo zypper install -y podman" ;;
+                *)      echo "  See https://docs.docker.com/engine/install/ or https://podman.io/getting-started/installation" ;;
+            esac
+            echo "  Rootless podman needs no daemon and no group membership."
+            ;;
+        windows)
+            cat <<'EOF'
+  Install Docker Desktop: https://www.docker.com/products/docker-desktop/
+  Enable the WSL2 backend during setup, then re-run this script.
+EOF
+            ;;
+        macos)
+            cat <<'EOF'
+  Docker Desktop: https://www.docker.com/products/docker-desktop/
+  Podman:         brew install podman && podman machine init && podman machine start
+EOF
+            ;;
+        *)
+            echo "  https://docs.docker.com/engine/install/"
+            ;;
+    esac
+}
+
+install_engine() {
+    hdr "Installing a container engine"
+    if [ "$OS_KIND" = "windows" ] || [ "$OS_KIND" = "macos" ]; then
+        err "Automatic install is not supported on this OS - it needs a GUI installer."
+        print_install_help
+        return 1
+    fi
+    case "$PKG" in
+        apt)
+            info "Installing podman via apt (no daemon, no group setup needed)..."
+            sudo apt-get update && sudo apt-get install -y podman ;;
+        dnf)    sudo dnf install -y podman ;;
+        yum)    sudo yum install -y podman ;;
+        pacman) sudo pacman -S --noconfirm podman ;;
+        zypper) sudo zypper install -y podman ;;
+        *)      err "No supported package manager found."; print_install_help; return 1 ;;
+    esac
+}
+
+hdr "Container engine"
+find_engine
+
+if [ -z "$ENGINE" ]; then
+    err "Neither docker nor podman found on PATH."
+    if [ "$INSTALL_ENGINE" = "1" ]; then
+        install_engine || exit 1
+        find_engine
+        [ -n "$ENGINE" ] || { err "Install finished but no engine on PATH - reopen your shell."; exit 1; }
+    else
+        print_install_help
+        echo
+        info "Re-run with --install-engine to let this script install podman for you."
+        exit 1
+    fi
+fi
+
+ok "Found: $ENGINE ($("$ENGINE" --version 2>/dev/null | head -1))"
+
+if ! "$ENGINE" info >/dev/null 2>&1; then
+    err "$ENGINE is installed but not usable (daemon down, or permission denied)."
+    case "$OS_KIND" in
+        wsl)   warn "If using Docker Desktop: start it, and enable WSL integration for this distro." ;;
+        linux) warn "Try: sudo systemctl start docker    (and: sudo usermod -aG docker \"\$USER\", then re-login)" ;;
+        *)     warn "Start the engine, then re-run." ;;
+    esac
+    exit 1
+fi
+ok "$ENGINE is running"
+
+# ------------------------------------------------------------------ the image
+
+hdr "Verilator image"
+
+have_image() { "$ENGINE" image inspect "$IMAGE" >/dev/null 2>&1; }
+
+if [ "$MODE" = "check" ]; then
+    if have_image; then
+        ok "Image present: $IMAGE"
+        info "verilator: $("$ENGINE" run --rm "$IMAGE" --version 2>&1 | head -1)"
+    else
+        warn "Image NOT present: $IMAGE   (run this script without --check to pull it)"
+        exit 1
+    fi
+    hdr "Result"; ok "Environment looks good."; exit 0
+fi
+
+if [ "$MODE" = "load" ]; then
+    [ -r "$LOAD_FILE" ] || { err "Cannot read $LOAD_FILE"; exit 1; }
+    info "Loading $IMAGE from $LOAD_FILE (offline install)..."
+    "$ENGINE" load -i "$LOAD_FILE"
+elif have_image; then
+    ok "Image already present: $IMAGE"
+    info "Delete it with '$ENGINE rmi $IMAGE' if you want a fresh pull."
+else
+    info "Pulling $IMAGE (a few hundred MB, one time)..."
+    if ! "$ENGINE" pull "$IMAGE"; then
+        err "Pull failed."
+        warn "No internet? Export the image on a connected machine:"
+        warn "    $ENGINE pull $IMAGE && $ENGINE save $IMAGE | gzip > verilator-image.tar.gz"
+        warn "copy the file over, then here run:"
+        warn "    ./setup.sh --load verilator-image.tar.gz"
+        exit 1
+    fi
+fi
+
+have_image || { err "Image still missing after $MODE."; exit 1; }
+ok "Image ready: $IMAGE"
+
+VER="$("$ENGINE" run --rm "$IMAGE" --version 2>&1 | head -1)" \
+    && ok "Works: $VER" \
+    || { err "Image present but 'verilator --version' failed."; exit 1; }
+
+hdr "Next steps"
+cat <<EOF
+  cd \$ODVE/comp/agents/apb/vrf/work/run
+  source sourceme
+  make clean all run VERILATOR=1
+EOF
+[ "$ENGINE" != "docker" ] && info "Using $ENGINE: export ODVE_CONTAINER_ENGINE=$ENGINE to pin it."
+exit 0


### PR DESCRIPTION
Follow-up to #6. Adds the missing "download the image first" step as a real script, rather than something you have to know to do by hand.

## `odve/script/verilator-docker/setup.sh`

- **OS detection + reporting** — WSL (reports distro), native Linux (reports distro + package manager), Windows Git Bash/MSYS/Cygwin (warns WSL is the better-tested path here), macOS. Unknown OS warns and continues.
- **Engine detection** — docker or podman, honouring `ODVE_CONTAINER_ENGINE`. Distinguishes *not installed* from *installed but not running / permission denied*, and gives the right fix for each (start Docker Desktop + enable WSL integration, vs `systemctl start docker` / `usermod -aG docker`).
- **Engine install step** — prints per-OS instructions when nothing is found; `--install-engine` installs podman via apt/dnf/yum/pacman/zypper. Podman is chosen for the automated path because it needs no daemon and no group membership. Refuses to auto-install on Windows/macOS, where a GUI installer is required.
- **Image fetch** — pulls by default; `--load <tarball>` covers air-gapped hosts (e.g. CAD machines). A failed pull prints the exact save/copy/load sequence to use instead.
- Also `--check` (report only, changes nothing), `--image <ref>`, `--help`.

## Other changes

- `bin/verilator` now falls back to **podman** when docker is absent, using `--userns=keep-id` rather than `-u uid:gid` so rootless podman does not leave root-owned build output.
- Root `README.md` now leads with the container flow; the native/Cygwin install is kept as the documented alternative (setting `VERILATOR_ROOT` before `source sourceme` still bypasses the container).
- New `script/verilator-docker/README.md` covering options, env vars, the offline workflow, and how the path-identical mount works.

## Testing

Exercised `--check`, `--help`, unknown-option (exit 2), `--load` with a missing file and with no argument, and a real `--load` of a 249 MB saved image. Re-ran the full `make clean all run VERILATOR=1` afterwards to confirm the `bin/verilator` rewrite did not regress the build — clean UVM run, 0 errors / 0 fatals.

One bug found and fixed during testing: with `ODVE_CONTAINER_ENGINE` set to a nonexistent binary, `set -e` aborted the script silently before any diagnostic printed. It now warns and falls through to the install guidance.

## Note on location

Placed under the existing `odve/script/` (singular), alongside the wrapper from #6, rather than creating a parallel `odve/scripts/` tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)