### PR TITLE
Check Verilator as well as Questa in the vrf workflow

### DIFF
--- a/.claude/skills/vrf-workflow/SKILL.md
+++ b/.claude/skills/vrf-workflow/SKILL.md
@@ -1,22 +1,33 @@
 ---
 name: vrf-workflow
-description: Compile and simulate UVM/SystemVerilog agent code with Questa/ModelSim after editing files under odve/comp/agents/*/src, intf, item, seq, or vrf, and gate git commit/push on it. Use this proactively any time you modify, add, or remove a .sv file under odve/comp/agents/ (agent sources, interfaces, sequences, testbench env/tests, DUT) to confirm the change still compiles and the relevant test(s) still pass — do not report SystemVerilog edits as done without running this. ALWAYS use this before running `git commit` (analyze + compile must be clean) or `git push` (submit regression must be clean) on SystemVerilog changes in this repo. Also use when the user asks to "compile", "run a test", "check compilation", "run regression", or "run submit/check/mini" for an agent. Also applies if editing shared framework code under odve/script or odve/comp/common — re-run this for at least one agent (e.g. apb) to confirm the shared change didn't break the build.
+description: Compile and simulate UVM/SystemVerilog agent code with BOTH Questa/ModelSim and Verilator after editing files under odve/comp/agents/*/src, intf, item, seq, or vrf, and gate git commit/push on both. Use this proactively any time you modify, add, or remove a .sv file under odve/comp/agents/ (agent sources, interfaces, sequences, testbench env/tests, DUT) to confirm the change still compiles and the relevant test(s) still pass — do not report SystemVerilog edits as done without running this. ALWAYS use this before running `git commit` (analyze + compile must be clean on both simulators) or `git push` (submit regression must be clean on both simulators) on SystemVerilog changes in this repo. Also use when the user asks to "compile", "run a test", "check compilation", "run regression", or "run submit/check/mini" for an agent. Also applies if editing shared framework code under odve/script or odve/comp/common — re-run this for at least one agent (e.g. apb) to confirm the shared change didn't break the build.
 ---
 
 # VRF compile / run / regress workflow
 
-This repo's verification agents are Questa/ModelSim UVM environments where **compilation is filelist-driven, not directory-scanned**. Editing or adding a `.sv` file is not enough by itself — you must also (a) make sure it's referenced by the right filelist if it's new, and (b) actually run the build to know whether it compiles. There is no separate "syntax check" step; compiling *is* the check.
+This repo's verification agents are UVM environments where **compilation is filelist-driven, not directory-scanned**. Editing or adding a `.sv` file is not enough by itself — you must also (a) make sure it's referenced by the right filelist if it's new, and (b) actually run the build to know whether it compiles. There is no separate "syntax check" step; compiling *is* the check.
+
+**Two simulators are supported and both must be checked.** Questa/ModelSim is the primary simulator; Verilator runs the same filelists via `VERILATOR=1`. They disagree often — Verilator is stricter (it has already caught real bugs Questa accepted, e.g. interface ports with no direction, and missing `+incdir+` for a package's own includes), while Questa supports constructs Verilator does not. **A change that compiles on one can fail on the other, so passing one is not evidence about the other.**
 
 ## 0. Find the right agent and work folder
 
-Each agent lives at `odve/comp/agents/<agent>/` (`apb` is the most complete and currently the only one with a working `vrf/` environment set up — check before assuming another agent like `ahb`/`jtag`/`spi`/`uart` has one yet). Its standalone verification environment is `odve/comp/agents/<agent>/vrf/`, and the build/run/regress workspace is `odve/comp/agents/<agent>/vrf/work/<variant>/`, where `<variant>` is one of:
+Each agent lives at `odve/comp/agents/<agent>/` (`apb` is the most complete and currently the only one with a full `vrf/` UVM environment — check before assuming another agent like `ahb`/`jtag`/`spi`/`uart` has one). Its standalone verification environment is `odve/comp/agents/<agent>/vrf/`, and the build/run/regress workspace is `odve/comp/agents/<agent>/vrf/work/<variant>/`, where `<variant>` is one of:
 
 - `run/` — everyday compile + simulate loop while iterating on code.
 - `check/` or `submit/` — full regression, run before pushing.
 - `mini/` — a smaller/faster regression subset.
-- `common/` — not run directly; holds the shared `Makefile`/`sourceme` the other variants include.
+- `common/` — not run directly; holds the shared `Makefile`/`Makefile_veri`/`sourceme` the other variants include.
 
 If a change is only in `odve/script/` or `odve/comp/common/` (shared framework code, not agent-specific), still run this workflow for at least one agent afterward — those files are `include`d by every agent's build.
+
+### Does this agent support Verilator?
+
+Verilator support is per-agent, not automatic. An agent has it only if **both** exist:
+
+- `vrf/work/common/Makefile_veri` — the Verilator build rules, and
+- `vrf/list/fl.f` — the single flattened filelist Verilator consumes (Questa uses the separate `fl_uvm.f`/`fl_dut.f`/`fl_tb.f`).
+
+Today that's `apb` (full UVM) and `uart` (non-UVM). If an agent lacks them, say so plainly rather than reporting a Verilator pass that never ran — and don't hand-roll a one-off `verilator` invocation as a substitute, since it won't match what the Makefile does.
 
 ## 1. Source the environment (once per shell)
 
@@ -25,69 +36,108 @@ cd odve/comp/agents/<agent>/vrf/work/<variant>
 source sourceme
 ```
 
-This exports `ODVE`, `ODVE_<AGENT>`, and `PROJ` as absolute paths and pulls in `odve/script/source/common_sourceme` (sets `ODVE_UVM`, locates `MS_HOME` from `vsim` on `PATH`). If `vsim` isn't on `PATH` in this environment, `sourceme`/`make` will fail early — tell the user Questa/ModelSim isn't available rather than guessing at results.
+Exports `ODVE`, `ODVE_<AGENT>`, `PROJ`, and pulls in `odve/script/source/common_sourceme` (sets `ODVE_UVM`, locates `MS_HOME` from `vsim` on `PATH`, and points `VERILATOR_ROOT` at the containerised Verilator in `odve/script/verilator-docker/`).
+
+**Verilator prerequisite:** the container image must be present. If `make ... VERILATOR=1` complains that no engine or image is available, run `odve/script/verilator-docker/setup.sh` (`--check` to inspect without changing anything). It needs docker or podman, nothing else.
+
+**Questa prerequisite:** `vsim` on `PATH`. If it isn't, say Questa isn't available rather than guessing at results.
+
+### Know which simulators actually work *in this environment* before promising both
+
+Check, don't assume — and report per-simulator rather than collapsing to one verdict:
+
+- **WSL:** Verilator works. Questa often does **not**, even when `vsim` resolves: a Windows ModelSim binary cannot read WSL paths, and the build dies with `Failed to open -f file "/mnt/c/..."`. Questa needs Windows-native `C:/...` paths, i.e. run it from **Git Bash on Windows**, not WSL.
+- **Git Bash on Windows:** Questa works. Verilator works if Docker Desktop is running.
+- **Native Linux:** Verilator works; Questa works if a Linux Questa is installed.
+
+If you can only run one simulator, run it, then **explicitly state that the other was not verified and why**. Never imply both passed when only one ran.
 
 ## 2. Compile
 
+**Questa:**
 ```bash
 make all
 ```
+Runs `prework preuvm auvm uvm_dpi predut adut pretb atb elib` — compiles UVM, DUT and TB into separate Questa libraries (`vlog`), then elaborates (`vopt`). **Read the actual output**; each `vlog`/`vopt` step prints `Errors: N, Warnings: M` and any nonzero error count is a real failure.
 
-This runs `prework preuvm auvm uvm_dpi predut adut pretb atb elib` — compiles UVM, DUT, and TB into separate Questa libraries (`vlog`), then elaborates (`vopt`). **Read the actual output**, don't assume success from exit code alone: each `vlog`/`vopt` step prints a summary line like `Errors: 0, Warnings: 2` — any nonzero error count is a real compile failure to fix before moving on.
+`auvm`/`adut`/`atb` are the **analyze** steps (`vlog`) for the UVM, DUT and TB layers, runnable individually if you only touched one layer (e.g. `make atb` after a testbench-only edit). `elib`/`elab` is the separate **elaborate** step (`vopt`) that links them. A file can analyze cleanly yet fail to elaborate (e.g. a missing cross-package class reference), so don't treat "analyze passed" as "compilation is ok."
 
-`auvm`/`adut`/`atb` are Questa's **analyze** steps — they run `vlog` (which "analyzes" HDL into a library) for the UVM, DUT, and TB layers respectively, and can be run individually if you only touched one layer (e.g. `make atb` after a testbench-only change). `elib`/`elab` is the separate **elaborate** step (`vopt`) that links the analyzed libraries together. A source file can analyze cleanly on its own yet still fail to elaborate (e.g. a missing class reference across packages) — `make all` (or the narrower `make <layer> elib`) is what proves both, so don't treat "analyze passed" alone as "compilation is ok."
+**Verilator:**
+```bash
+make all VERILATOR=1        # VERI=1 is an equivalent legacy spelling
+```
+One step: elaborates and compiles the generated C++ into `obj_dir/Vtop`. It is slower than Questa (several minutes — it compiles all of UVM through g++), so expect the wait and don't kill it early. Warnings are non-fatal by design (`-Wno-fatal`), because the vendored UVM 1.1d and the existing TB trip width/pin warnings that are not worth failing on — so **read the output for `%Error:` lines specifically**; a nonzero exit is the reliable signal.
 
-If you added or removed a source file (not just edited an existing one), first check it's listed in the right filelist — otherwise it silently won't be compiled (or `vlog` will complain about a missing file):
-- Agent-side files (`src/`, `item/`, `seq/`, `intf/`) → `odve/comp/agents/<agent>/list/*.f` (`agent.f`, `item.f`, `seq.f`).
-- Testbench-side files (`vrf/tb/`, `vrf/dut/`) → `odve/comp/agents/<agent>/vrf/list/fl_tb.f` or `fl_dut.f`.
+If you added or removed a source file (not just edited one), check it's in the right filelist or it silently won't compile:
+- Agent-side (`src/`, `item/`, `seq/`, `intf/`) → `odve/comp/agents/<agent>/list/*.f`.
+- Testbench-side (`vrf/tb/`, `vrf/dut/`) → `vrf/list/fl_tb.f` / `fl_dut.f`.
+- **And for Verilator:** confirm `vrf/list/fl.f` still pulls in the filelist you changed — it's a separate entry point, so a file added only to `fl_tb.f` is picked up by both, but a restructure of the `fl_*.f` files can silently drop Verilator coverage.
 
-If you changed the interface used elsewhere or touched shared framework code (`odve/script/common/common.mk`, `odve/comp/common/`), run a clean rebuild instead of an incremental one:
+After interface changes or shared-framework edits (`script/common/common.mk`, `comp/common/`), rebuild clean rather than incrementally:
 
 ```bash
-make aclean all
+make aclean all              # Questa
+make aclean all VERILATOR=1  # Verilator
 ```
 
 ## 3. Run a specific test
 
 ```bash
-make TESTNAME=<test_name> run
+make TESTNAME=<test_name> run                # Questa
+make TESTNAME=<test_name> run VERILATOR=1    # Verilator
 ```
 
-`<test_name>` is a UVM test class from `vrf/tb/tests/` (e.g. `read_test`, `write_test`, `simple_test`; default is `base_test`). This invokes `vsim` with `+UVM_TESTNAME=$(TESTNAME)` and writes `run.log` under the run directory (`$(TESTNAME)__run/` by default). **Check the log's UVM report summary** (the `UVM_ERROR :` / `UVM_FATAL :` counts near the end) — a test can finish without a Questa error yet still have failed inside UVM.
+`<test_name>` is a UVM test class from `vrf/tb/tests/` (default under Questa is `base_test`). Both paths pass `+UVM_TESTNAME=<name>` and write `run.log` into a per-test run directory (`<TESTNAME>__run/`, or `RUN_DIR` if set).
 
-Combine compile + run in one step during iteration:
+**Check the UVM report summary in the log** (`UVM_ERROR :` / `UVM_FATAL :` near the end) — a test can exit 0 at the tool level and still have failed inside UVM. The Verilator `run` target additionally greps the log and fails the make target on nonzero `UVM_ERROR`/`UVM_FATAL`, but confirm the numbers yourself rather than trusting exit code alone.
+
+**Watch for the silent-wrong-test trap.** With no `TESTNAME`, the Verilator path runs whatever `top.sv`'s `run_test()` call hardcodes rather than a named test. So a run can look green while exercising something other than what you asked for. Confirm the log's `Running test <name>...` line matches the test you intended — if you passed a `TESTNAME` and the log names a different test, treat it as a failure, not a pass.
+
+Combine compile + run while iterating:
 
 ```bash
-make aclean all run TESTNAME=<test_name>
+make aclean all run TESTNAME=<test_name>                # Questa
+make aclean all run TESTNAME=<test_name> VERILATOR=1    # Verilator
 ```
 
-## 4. Run the full regression before pushing
+## 4. Run the full regression before pushing — on both simulators
 
-Every `work/<variant>` folder (`run/`, `mini/`, and `check/` where it exists) has its own `regress.py`/`sourceme` — you don't need a dedicated folder per list name, the list name is just an argument:
+Every `work/<variant>` folder has its own `regress.py`/`sourceme`; the list name is just an argument:
 
 ```bash
-cd odve/comp/agents/<agent>/vrf/work/run   # any variant folder works
+cd odve/comp/agents/<agent>/vrf/work/run
 source sourceme
-./regress.py submit
+
+./regress.py submit                        # Questa
+./regress.py submit -ropts="VERILATOR=1"   # Verilator, same list
 ```
 
-`regress.py <name>` reads `work/rlist/<name>.list` (each line names a run with its own `TESTNAME`/`COMP_DIR`/`RUN_OPTS` overrides) and drives `odve/script/regress/regress.py`, which runs the jobs in parallel (default up to 4 at once). `submit` is the pre-push regression list (`work/rlist/submit.list`, alongside `mini.list`); confirm which list name the user means if unclear, and don't invent a new list name without checking `work/rlist/` first.
+`-ropts` appends make variables to **both** the compile job and every run job, so the list is built and run with the same simulator. (Omitting it from the compile would build with Questa and run with Verilator.) Anything else make accepts works too, e.g. `-ropts="VERILATOR=1 NPROC=8"`.
 
-If a change touched `odve/script/regress/` itself (`regress.py`, `readlist.py`, `list2json.py`, `jobrunner.py`), test it against a real agent's `rlist/*.list` (e.g. `apb`) rather than reasoning about it in the abstract.
+`regress.py <name>` reads `work/rlist/<name>.list` (each line names a run with its own `TESTNAME`/`COMP_DIR`/`RUN_OPTS` overrides) and drives `odve/script/regress/regress.py`, running jobs in parallel (default 4, `-max_jobs` to change). `submit` is the pre-push list; confirm which list the user means if unclear, and check `work/rlist/` before inventing a name. `-no_comp` reuses an existing build — useful when iterating, but never for the final pre-push run.
+
+Read the per-job results, not just the exit code: `regress.py` fails the run if any job returns nonzero **or** reports `UVM_ERROR`/`UVM_FATAL`, and prints each job's captured output. Confirm every job in the list actually ran.
+
+Regression output lands in `RUN_DIR` named after the list entry (e.g. `apb_read/`), not `<TESTNAME>__run/`.
+
+If you changed `odve/script/regress/` itself (`regress.py`, `readlist.py`, `list2json.py`, `jobrunner.py`), exercise it against a real list (e.g. `apb`'s `submit`) **under both simulators**, since `-ropts` and the command construction affect both.
 
 ## 5. Gate on git commit and push
 
-This is a hard sequence, not a suggestion — SystemVerilog changes are silently broken far more often than software changes, because there's no compiler running in the editor and no type system catching mistakes until `vlog` runs. Never skip a step because "it's a small change." This applies to changes under `odve/comp/agents/` and to shared framework changes under `odve/script/` or `odve/comp/common/` (verify against a real agent, e.g. `apb`).
+A hard sequence, not a suggestion — SystemVerilog breaks silently far more often than software, because nothing checks it until `vlog`/`verilator` runs. Never skip a step because "it's a small change." Applies to `odve/comp/agents/` and to shared framework changes under `odve/script/` or `odve/comp/common/` (verify against a real agent, e.g. `apb`).
 
-**Before `git commit`** (any commit touching `.sv`/`.f`/`Makefile` files):
-1. Run analyze on whatever layer(s) changed — `make atb` for testbench-only edits, `make adut` for DUT edits, `make auvm` if UVM library config changed, or just `make auvm adut atb` for all three. Fix every nonzero `Errors:` count.
-2. Run `make all` (which includes `elib`) to confirm it elaborates too — analyze-clean doesn't mean elaborate-clean (see step 2). Only commit once this is clean.
+**Before `git commit`** (any commit touching `.sv`/`.f`/`Makefile`/regress scripts):
+1. Questa: analyze the changed layer(s) — `make atb` / `make adut` / `make auvm`, or `make auvm adut atb`. Fix every nonzero `Errors:` count.
+2. Questa: `make all` (includes `elib`) to prove it elaborates too.
+3. Verilator: `make all VERILATOR=1` — for any agent that supports it (see §0). This is the step most likely to surface a real defect, since Verilator is the stricter of the two.
 
 **Before `git push`**:
-3. Run the `submit` regression (step 4 above): `./regress.py submit` from a `work/<variant>` folder. Read the results for every job in the list, not just the last one — confirm each ran and passed (no `UVM_ERROR`/`UVM_FATAL`, no Questa `Errors:` > 0). If any job fails, fix it and re-run the full list before pushing; don't push on a partial regression.
+4. `./regress.py submit` (Questa) **and** `./regress.py submit -ropts="VERILATOR=1"` (Verilator). Both must be clean. Fix and re-run the **full** list on both before pushing; never push on a partial regression or on one simulator's result alone.
 
-If asked to commit/push and you haven't just run this sequence in the current conversation, run it first — don't rely on an earlier compile from before the latest edits.
+If a simulator genuinely cannot run in the current environment (see §1), do not silently skip it — run what you can, and tell the user which simulator went unverified and why, so they can run it where it works before merging.
+
+If asked to commit/push and you haven't just run this sequence in the current conversation, run it first — don't rely on a compile from before the latest edits.
 
 ## After running
 
-Summarize what you ran (compile-only vs. specific test vs. regression), the pass/fail result from the log, and — if it failed — quote the specific error/UVM_ERROR lines rather than just saying "it failed." If compilation or simulation couldn't run at all (e.g. `vsim` missing), say so explicitly instead of reporting success.
+Summarize **per simulator**: what you ran (compile-only vs. specific test vs. regression) and the pass/fail result from the log. If something failed, quote the specific `%Error:` / `Errors: N` / `UVM_ERROR` lines rather than saying "it failed." If a simulator couldn't run at all, say so explicitly instead of reporting success or quietly omitting it.

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ odve/script/regress/__pycache__/*
 odve/comp/agents/*/vrf/work/run/*__run/*
 odve/comp/agents/*/vrf/work/run/build/*
 odve/comp/agents/*/vrf/work/run/obj_dir/*
+# regress.py names RUN_DIR after the list entry, not <TESTNAME>__run
+odve/comp/agents/*/vrf/work/*/*/run.log
+odve/comp/agents/*/vrf/work/run/modelsim.ini
+odve/comp/agents/*/vrf/work/run/transcript

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file provides guidance to AI coding agents (Claude Code, Codex, etc.) when 
 
 `open-dve` is a UVM/SystemVerilog verification framework ("Open Design Verification Environment") that unifies testbench compilation, running, and regression across multiple agents/VIPs (APB, AHB, AXI, PCIe, NVMe, MPHY, UNIPRO, UFS — per the roadmap in `README.md`; several are still placeholders). Its content lives under `odve/` (this repo is consumed as the `odve` git submodule by downstream repos such as `amba-axi`, where it's checked out at `<downstream>/odve`).
 
-Targets Mentor/Siemens **Questa/ModelSim** (`vlog`/`vsim`/`vmap`/`vlib`) as the primary simulator; Verilator support exists but is currently disabled in `script/source/common_sourceme`. See `README.md` for Questa/Verilator toolchain install prerequisites (make, python3, bash, readlink, and — for Verilator on Windows — Cygwin, gcc-g++ 10+, flex, bison, autoconf).
+Targets Mentor/Siemens **Questa/ModelSim** (`vlog`/`vsim`/`vmap`/`vlib`) as the primary simulator, with **Verilator** as a supported second simulator via `make ... VERILATOR=1` (legacy spelling `VERI=1`). Both are expected to pass before commit/push — see the `vrf-workflow` skill. See `README.md` for toolchain prerequisites (make, python3, bash, readlink; Verilator runs from a container, needing only docker or podman — run `script/verilator-docker/setup.sh` once to fetch the image).
 
 ## Commands
 
@@ -48,7 +48,8 @@ source sourceme
 - `comp/agents/<protocol>/` — one UVM agent per protocol: `apb`, `axi`, `ahb`, `jtag`, `spi`, `uart`. **`apb` is the most complete and is the best reference implementation** to copy patterns from when building out another agent.
 - `comp/common/` — shared base classes (`base/odve_common_base_item.sv`) and macros (`macro/odve_macro.sv`, e.g. `` `odve_rand(obj) `` calls `obj.user_randomize()`).
 - `script/common/common.mk` — the single shared Make include behind every agent's `vrf/work/*/Makefile`. Defines the `prework/preuvm/auvm/predut/adut/pretb/atb/elib/run/clean/rclean/aclean` targets and the `FL_TB`/`FL_UVM`/`FL_DUT`/`TOP`/`TESTNAME`/`RUN_DIR`/`COMP_DIR` variables.
-- `script/source/common_sourceme` — sets `ODVE_UVM` and locates the Questa install (`MS_HOME`) from `vsim` on `PATH`. Verilator env vars are present but commented out.
+- `script/source/common_sourceme` — sets `ODVE_UVM`, locates the Questa install (`MS_HOME`) from `vsim` on `PATH`, and points `VERILATOR_ROOT` at the containerised Verilator in `script/verilator-docker/` (preset `VERILATOR_ROOT` yourself to use a native install instead).
+- `script/verilator-docker/` — containerised Verilator: `setup.sh` (one-time image fetch, with OS/engine detection and an offline `--load` path) and `bin/verilator` (docker/podman shim used as `$VERILATOR_ROOT/bin/verilator`).
 - `script/regress/` — the regression runner: `regress.py` (entry point), `readlist.py` (parses `*.list` files), `list2json.py` (converts parsed runs to job commands), `jobrunner.py` (parallel job execution), `list2json.py`.
 - `script/schedule/`, `script/pdf/pdf2req/` — scheduling and requirements-doc tooling (early/placeholder).
 - `uvm/` — vendored UVM library sources: `uvm-1.1d` (default, per `common_sourceme`) and `1800.2-2020-2.0` (available, not default). Used instead of relying on a simulator-provided UVM.

--- a/odve/comp/agents/apb/vrf/work/common/Makefile_veri
+++ b/odve/comp/agents/apb/vrf/work/common/Makefile_veri
@@ -24,14 +24,39 @@ BUILD_OPTS = \
 # -sv_lib. --vpi above pulls in the vpi_* runtime it calls into.
 DPI_SRCS = ${ODVE_UVM}/src/dpi/uvm_dpi.cc
 
+# Mirror common.mk: a named test goes to UVM as a plusarg, and each run gets
+# its own directory holding run.log. TESTNAME is deliberately NOT defaulted -
+# with no name the TB falls back to the run_test() call in top.sv, and any
+# name given is passed through so a bad one fails loudly here exactly as it
+# would under Questa (rather than silently running whatever top.sv picked).
+TESTNAME ?=
+ifneq ($(strip $(TESTNAME)),)
+	TEST_PLUSARG = +UVM_TESTNAME=$(TESTNAME)
+	RUN_DIR ?= $(TESTNAME)__run
+else
+	TEST_PLUSARG =
+	RUN_DIR ?= default__run
+endif
+
 clean:
 	rm -rf obj_dir
+
+rclean:
+	rm -rf ./*__run
+
+aclean: clean rclean
 
 all:
 	$(VERILATOR_ROOT)/bin/verilator $(BUILD_OPTS) -F $(VRF)/list/fl.f $(DPI_SRCS)
 
 run:
-	./obj_dir/$(BIN)
+	mkdir -p $(RUN_DIR)
+	cd $(RUN_DIR); ./../obj_dir/$(BIN) $(TEST_PLUSARG) $(RUN_OPTS) > run.log 2>&1; \
+		rc=$$?; cat run.log; \
+		if [ $$rc -ne 0 ]; then echo "*** $(BIN) exited $$rc"; exit $$rc; fi; \
+		if grep -qE '^UVM_(ERROR|FATAL) *: *[1-9]' run.log; then \
+			echo "*** UVM errors reported - see $(RUN_DIR)/run.log"; exit 1; \
+		fi
 
 version:
 	$(VERILATOR_ROOT)/bin/verilator --version

--- a/odve/script/regress/list2json.py
+++ b/odve/script/regress/list2json.py
@@ -7,13 +7,19 @@ class list2json:
     def convert2j (self, list):
         for line in list :
             parts = line.split(":")
-            self.data[parts[0]] = {"cmd" : parts[1]} 
-        return self.data  
-    
-    def gencmd (self, data):
+            self.data[parts[0]] = {"cmd" : parts[1]}
+        return self.data
+
+    def gencmd (self, data, ropts=""):
+        """Build one `make run` command per run in the list. `ropts` holds extra
+        make variables applied to every job (e.g. "VERILATOR=1" to drive the
+        list against Verilator instead of Questa)."""
         cmds = []
+        ropts = (ropts or "").strip()
         for run in data :
             cmd=f'make run RUN_DIR={run} {data[run]["cmd"]}'
+            if ropts:
+                cmd=f'{cmd} {ropts}'
             cmds.append(cmd)
-        return cmds  
-    
+        return cmds
+

--- a/odve/script/regress/regress.py
+++ b/odve/script/regress/regress.py
@@ -47,6 +47,10 @@ def main():
     parser.add_argument("-opts", "--opts", help="Output JSON file")
     parser.add_argument("-max_jobs", "--max_jobs", type=int, default=4, help="Max parallel jobs")
     parser.add_argument("-no_comp", "--no_comp", action="store_true", help="Skip the compile step and run the list against the existing build")
+    parser.add_argument("-ropts", "--ropts", default="",
+                        help='Extra make variables applied to BOTH the compile and the run jobs, '
+                             'e.g. -ropts="VERILATOR=1" (or "VERI=1") to run the list under '
+                             'Verilator instead of Questa')
 
     args = parser.parse_args()
     maxj = args.max_jobs
@@ -61,12 +65,17 @@ def main():
     l2j = list2json ()
     cmdsj = l2j.convert2j(rf.getlines())
     print(json.dumps(cmdsj, indent=4))
-    cmdsl = l2j.gencmd(cmdsj)
+    cmdsl = l2j.gencmd(cmdsj, args.ropts)
     print (cmdsl)
+
+    if args.ropts:
+        print(f"extra make args (-ropts): {args.ropts}")
 
     if not args.no_comp:
         jc = JobRunner(maxj)
-        comp_jobs = ["make clean all"]
+        # -ropts must reach the compile too, otherwise the list would be built
+        # with one simulator and run with another.
+        comp_jobs = [f"make clean all {args.ropts}".rstrip()]
         results=jc.run_jobs(comp_jobs)
         print (results)
         if any(job_failed(r) for r in results):


### PR DESCRIPTION
Follow-up to #6 and #7. Regression and the pre-commit / pre-push gate now cover **both** simulators instead of Questa alone.

## Two real bugs found

**1. The Verilator run target silently ignored `TESTNAME` — a false PASS.** `run:` was just `./obj_dir/$(BIN)`, with no `+UVM_TESTNAME`. Demonstrated by asking for a test that does not exist:

```
make run TESTNAME=this_test_does_not_exist VERILATOR=1
→ "Running test read_test..."   UVM_ERROR: 0   exit 0     # green, wrong test
```

Any Verilator regression would have reported success while running whatever `top.sv` hardcodes, regardless of what the list asked for. Now the same command gives `UVM_FATAL ... not found` and exit 2, matching Questa. The target also writes `run.log` into a per-run directory and fails on nonzero `UVM_ERROR`/`UVM_FATAL`. Adds `rclean`/`aclean` to match `common.mk`.

**2. `regress.py` could not drive Verilator at all.** Both the run command and the compile step (`make clean all`) were hardcoded. New `-ropts` is applied to the compile job *and* every run job — applying it only to runs would build with one simulator and run with the other:

```bash
./regress.py submit                        # Questa
./regress.py submit -ropts="VERILATOR=1"   # Verilator, same list
```

## Skill / docs

`vrf-workflow` now requires both simulators before commit (`make all` and `make all VERILATOR=1`) and before push (both regressions), and documents:
- how to tell whether an agent supports Verilator at all (needs both `vrf/work/common/Makefile_veri` and `vrf/list/fl.f` — today `apb` and `uart`),
- the silent-wrong-test trap above, and to check the `Running test <name>` line matches what was requested,
- that Questa cannot run from WSL (Windows binary, cannot read `/mnt/c` paths), so an unverified simulator must be reported explicitly rather than skipped quietly.

`AGENTS.md` no longer claims Verilator is disabled. `.gitignore` picks up regression `run.log`s, whose `RUN_DIR` is named after the list entry rather than `<TESTNAME>__run`.

## Verification — please read

- **Verilator:** compile, single test, and the full `submit` regression via `-ropts` all verified passing, plus the negative case (bad `TESTNAME` now fails).
- **Questa: not verified.** Questa is installed in my environment but is a Windows binary and cannot read WSL paths (`Failed to open -f file "/mnt/c/..."`), so it needs Git Bash on Windows.

The `regress.py` / `list2json.py` changes sit on the shared Questa path too. They are conservative — `-ropts` defaults to empty, so generated commands are byte-identical to before when unused — but **please run `./regress.py submit` from Git Bash on Windows before merging** to confirm the Questa path is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)